### PR TITLE
api/client: receive multiaddr target address

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 
+	"github.com/multiformats/go-multiaddr"
 	dealsPb "github.com/textileio/powergate/deals/pb"
 	ffsRpc "github.com/textileio/powergate/ffs/rpc"
 	healthRpc "github.com/textileio/powergate/health/rpc"
@@ -11,6 +12,7 @@ import (
 	slashingPb "github.com/textileio/powergate/index/slashing/pb"
 	netRpc "github.com/textileio/powergate/net/rpc"
 	reputationPb "github.com/textileio/powergate/reputation/pb"
+	"github.com/textileio/powergate/util"
 	walletPb "github.com/textileio/powergate/wallet/pb"
 	"google.golang.org/grpc"
 )
@@ -54,9 +56,13 @@ func (t TokenAuth) RequireTransportSecurity() bool {
 	return t.secure
 }
 
-// NewClient starts the client
-func NewClient(target string, opts ...grpc.DialOption) (*Client, error) {
-	conn, err := grpc.Dial(target, opts...)
+// NewClient creates a client
+func NewClient(ma multiaddr.Multiaddr, opts ...grpc.DialOption) (*Client, error) {
+	addr, err := util.TCPAddrFromMultiAddr(ma)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/multiformats/go-multiaddr"
 	"google.golang.org/grpc"
 )
 
@@ -11,7 +12,11 @@ func TestClient(t *testing.T) {
 	done := setupServer(t)
 	defer done()
 
-	client, err := NewClient(grpcHostAddress, grpc.WithInsecure())
+	ma, err := multiaddr.NewMultiaddr(grpcHostAddress)
+	if err != nil {
+		t.Fatalf("parsing multiaddress: %s", err)
+	}
+	client, err := NewClient(ma, grpc.WithInsecure())
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/api/client/test_utils.go
+++ b/api/client/test_utils.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 	"github.com/textileio/powergate/api/server"
 	"github.com/textileio/powergate/tests"
@@ -15,7 +16,7 @@ import (
 
 var (
 	grpcHostNetwork     = "tcp"
-	grpcHostAddress     = "127.0.0.1:5002"
+	grpcHostAddress     = "/ip4/127.0.0.1/tcp/5002"
 	grpcWebProxyAddress = "127.0.0.1:6002"
 	gatewayHostAddr     = "0.0.0.0:7000"
 	ctx                 = context.Background()
@@ -57,7 +58,11 @@ func setupServer(t *testing.T) func() {
 
 func setupConnection(t *testing.T) (*grpc.ClientConn, func()) {
 	auth := TokenAuth{}
-	conn, err := grpc.Dial(grpcHostAddress, grpc.WithInsecure(), grpc.WithPerRPCCredentials(auth))
+	ma, err := multiaddr.NewMultiaddr(grpcHostAddress)
+	checkErr(t, err)
+	addr, err := util.TCPAddrFromMultiAddr(ma)
+	checkErr(t, err)
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithPerRPCCredentials(auth))
 	checkErr(t, err)
 	return conn, func() {
 		require.NoError(t, conn.Close())

--- a/api/client/test_utils.go
+++ b/api/client/test_utils.go
@@ -35,6 +35,7 @@ func setupServer(t *testing.T) func() {
 	ddevnet := tests.LaunchDevnetDocker(t, 1)
 	devnetAddr := util.MustParseAddr("/ip4/127.0.0.1/tcp/" + ddevnet.GetPort("7777/tcp"))
 
+	grpcMaddr := util.MustParseAddr(grpcHostAddress)
 	conf := server.Config{
 		WalletInitialFunds:  *big.NewInt(int64(4000000000)),
 		IpfsAPIAddr:         ipfsAddr,
@@ -43,7 +44,7 @@ func setupServer(t *testing.T) func() {
 		LotusMasterAddr:     "",
 		Embedded:            true,
 		GrpcHostNetwork:     grpcHostNetwork,
-		GrpcHostAddress:     grpcHostAddress,
+		GrpcHostAddress:     grpcMaddr,
 		GrpcWebProxyAddress: grpcWebProxyAddress,
 		RepoPath:            repoPath,
 		GatewayHostAddr:     gatewayHostAddr,

--- a/exe/cli/cmd/root.go
+++ b/exe/cli/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	client "github.com/textileio/powergate/api/client"
@@ -46,7 +47,9 @@ var (
 
 			auth := client.TokenAuth{}
 			opts = append(opts, grpc.WithPerRPCCredentials(auth))
-			fcClient, err = client.NewClient(target, opts...)
+			ma, err := multiaddr.NewMultiaddr(target)
+			checkErr(err)
+			fcClient, err = client.NewClient(ma, opts...)
 			checkErr(err)
 		},
 	}
@@ -64,7 +67,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.powergate.yaml)")
-	rootCmd.PersistentFlags().String("serverAddress", "127.0.0.1:5002", "address of the filecoin service api")
+	rootCmd.PersistentFlags().String("serverAddress", "/ip4/127.0.0.1/tcp/5002", "address of the filecoin service api")
 }
 
 func initConfig() {

--- a/exe/server/main.go
+++ b/exe/server/main.go
@@ -17,6 +17,7 @@ import (
 	"contrib.go.opencensus.io/exporter/prometheus"
 	logging "github.com/ipfs/go-log/v2"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -85,6 +86,11 @@ func main() {
 		}
 	}
 
+	grpcHostMaddr, err := multiaddr.NewMultiaddr(config.GetString("grpchostaddr"))
+	if err != nil {
+		log.Fatalf("parsing grpchostaddr: %s", err)
+	}
+
 	conf := server.Config{
 		WalletInitialFunds: *big.NewInt(config.GetInt64("walletinitialfund")),
 		IpfsAPIAddr:        util.MustParseAddr(config.GetString("ipfsapiaddr")),
@@ -94,7 +100,7 @@ func main() {
 		Embedded:           embedded,
 		// ToDo: Support secure gRPC connection
 		GrpcHostNetwork:     "tcp",
-		GrpcHostAddress:     util.MustParseAddr("grpchostaddr"),
+		GrpcHostAddress:     grpcHostMaddr,
 		GrpcWebProxyAddress: config.GetString("grpcwebproxyaddr"),
 		RepoPath:            repoPath,
 		GatewayHostAddr:     config.GetString("gatewayhostaddr"),

--- a/exe/server/main.go
+++ b/exe/server/main.go
@@ -32,7 +32,7 @@ var (
 func main() {
 	pflag.Bool("debug", false, "enable debug log levels")
 	pflag.Bool("pprof", false, "enable pprof endpoint")
-	pflag.String("grpchostaddr", "0.0.0.0:5002", "grpc host listening address")
+	pflag.String("grpchostaddr", "/ip4/0.0.0.0/tcp/5002", "grpc host listening address")
 	pflag.String("grpcwebproxyaddr", "0.0.0.0:6002", "grpc webproxy listening address")
 	pflag.String("lotushost", "/ip4/127.0.0.1/tcp/1234", "lotus full-node address")
 	pflag.String("lotustoken", "", "lotus full-node auth token")
@@ -94,7 +94,7 @@ func main() {
 		Embedded:           embedded,
 		// ToDo: Support secure gRPC connection
 		GrpcHostNetwork:     "tcp",
-		GrpcHostAddress:     config.GetString("grpchostaddr"),
+		GrpcHostAddress:     util.MustParseAddr("grpchostaddr"),
 		GrpcWebProxyAddress: config.GetString("grpcwebproxyaddr"),
 		RepoPath:            repoPath,
 		GatewayHostAddr:     config.GetString("gatewayhostaddr"),


### PR DESCRIPTION
Use multiaddr for creating the client. Popped up while adjusting some things for Buckets integration.