### PR TITLE
change cbor to json marshaling

### DIFF
--- a/chainstore/chainstore.go
+++ b/chainstore/chainstore.go
@@ -2,6 +2,7 @@ package chainstore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/bits"
 	"sort"
@@ -11,7 +12,6 @@ import (
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
-	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
 )
 
@@ -109,7 +109,7 @@ func (s *Store) load(tsk types.TipSetKey, v interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error getting key %s: %s", key, err)
 	}
-	if err := cbor.DecodeInto(buf, v); err != nil {
+	if err := json.Unmarshal(buf, v); err != nil {
 		return err
 	}
 	return nil
@@ -142,7 +142,7 @@ func (s *Store) save(ts types.TipSetKey, state interface{}) error {
 		return nil
 	}
 	defer txn.Discard()
-	buf, err := cbor.DumpObject(state)
+	buf, err := json.Marshal(state)
 	if err != nil {
 		return err
 	}

--- a/chainstore/chainstore_test.go
+++ b/chainstore/chainstore_test.go
@@ -3,13 +3,11 @@ package chainstore
 import (
 	"context"
 	"crypto/rand"
-	"os"
 	"testing"
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/ipfs/go-cid"
-	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/multiformats/go-multihash"
 	"github.com/textileio/powergate/tests"
 )
@@ -21,12 +19,6 @@ type data struct {
 
 type extraData struct {
 	Pos int
-}
-
-func TestMain(m *testing.M) {
-	cbor.RegisterCborType(data{})
-	cbor.RegisterCborType(extraData{})
-	os.Exit(m.Run())
 }
 
 func TestLoadFromEmpty(t *testing.T) {

--- a/index/ask/ask.go
+++ b/index/ask/ask.go
@@ -2,6 +2,7 @@ package ask
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"sync"
@@ -11,7 +12,6 @@ import (
 	"github.com/filecoin-project/lotus/api/apistruct"
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/ipfs/go-datastore"
-	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/textileio/powergate/signaler"
 	"go.opencensus.io/stats"
@@ -159,7 +159,7 @@ func (ai *Index) update() error {
 		return err
 	}
 
-	buf, err := cbor.DumpObject(newIndex)
+	buf, err := json.Marshal(newIndex)
 	if err != nil {
 		return err
 	}
@@ -279,7 +279,7 @@ func (ai *Index) loadFromStore() error {
 		}
 		return err
 	}
-	if err = cbor.DecodeInto(buf, &ai.index); err != nil {
+	if err = json.Unmarshal(buf, &ai.index); err != nil {
 		return err
 	}
 	return nil

--- a/index/ask/types.go
+++ b/index/ask/types.go
@@ -2,15 +2,7 @@ package ask
 
 import (
 	"time"
-
-	cbor "github.com/ipfs/go-ipld-cbor"
 )
-
-func init() {
-	cbor.RegisterCborType(IndexSnapshot{})
-	cbor.RegisterCborType(StorageAsk{})
-	cbor.RegisterCborType(time.Time{})
-}
 
 // IndexSnapshot contains Ask information from markets
 type IndexSnapshot struct {

--- a/index/miner/meta.go
+++ b/index/miner/meta.go
@@ -2,6 +2,7 @@ package miner
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/filecoin-project/go-address"
 	"github.com/filecoin-project/lotus/api/apistruct"
 	"github.com/filecoin-project/lotus/chain/types"
-	cbor "github.com/ipfs/go-ipld-cbor"
 	"github.com/textileio/powergate/iplocation"
 	"github.com/textileio/powergate/util"
 	"go.opencensus.io/stats"
@@ -166,7 +166,7 @@ func getMeta(ctx context.Context, c *apistruct.FullNodeStruct, h P2PHost, lr ipl
 
 // persisteMetaIndex saves to datastore a new MetaIndex
 func (mi *Index) persistMetaIndex(index MetaIndex) error {
-	buf, err := cbor.DumpObject(index)
+	buf, err := json.Marshal(index)
 	if err != nil {
 		return err
 	}

--- a/index/miner/miner_test.go
+++ b/index/miner/miner_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	cbor "github.com/ipfs/go-ipld-cbor"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
@@ -16,7 +15,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	cbor.RegisterCborType(time.Time{})
 	util.AvgBlockTime = time.Millisecond * 10
 	metadataRefreshInterval = time.Millisecond * 10
 	logging.SetAllLoggers(logging.LevelError)

--- a/index/miner/types.go
+++ b/index/miner/types.go
@@ -2,18 +2,7 @@ package miner
 
 import (
 	"time"
-
-	cbor "github.com/ipfs/go-ipld-cbor"
 )
-
-func init() {
-	cbor.RegisterCborType(IndexSnapshot{})
-	cbor.RegisterCborType(ChainIndex{})
-	cbor.RegisterCborType(Power{})
-	cbor.RegisterCborType(MetaIndex{})
-	cbor.RegisterCborType(Meta{})
-	cbor.RegisterCborType(Location{})
-}
 
 // IndexSnapshot contains on-chain and off-chain information about miners
 type IndexSnapshot struct {

--- a/index/slashing/types.go
+++ b/index/slashing/types.go
@@ -1,12 +1,5 @@
 package slashing
 
-import cbor "github.com/ipfs/go-ipld-cbor"
-
-func init() {
-	cbor.RegisterCborType(IndexSnapshot{})
-	cbor.RegisterCborType(Slashes{})
-}
-
 // IndexSnapshot contains slashing histoy information up-to a TipSetKey.
 type IndexSnapshot struct {
 	TipSetKey string


### PR DESCRIPTION
Avoid complex `init()` methods. Depending on how packages are imported, different types could be registered twice causing a panic.  Use json marshaling for saving things. If that's a problem, we should solve it differently than with global registrations (i.e: static generation).