### PR TITLE
index/ask improvements & go-memstat metrics & bound work to non-zero power miners

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,17 @@ clean:
 	rm -f powd pow powbench
 .PHONY: clean
 
+BUILD_FLAGS=CGO_ENABLED=0
 build-cli:
-	go build -o pow exe/cli/main.go
+	$(BUILD_FLAGS) go build -o pow exe/cli/main.go
 .PHONY: build-cli
 
 build-server:
-	go build -o powd exe/server/main.go
+	$(BUILD_FLAGS) go build -o powd exe/server/main.go
 .PHONY: build-server
 
 build-bench:
-	go build -o powbench exe/bench/main.go
+	$(BUILD_FLAGS) go build -o powbench exe/bench/main.go
 .PHONY: build-bench
 
 build: build-cli build-server build-bench

--- a/api/client/asks.go
+++ b/api/client/asks.go
@@ -15,7 +15,7 @@ type Asks struct {
 }
 
 // Get returns the current index of available asks
-func (a *Asks) Get(ctx context.Context) (*ask.IndexSnapshot, error) {
+func (a *Asks) Get(ctx context.Context) (*ask.Index, error) {
 	reply, err := a.client.Get(ctx, &pb.GetRequest{})
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func (a *Asks) Get(ctx context.Context) (*ask.IndexSnapshot, error) {
 	for key, val := range reply.GetIndex().GetStorage() {
 		storage[key] = askFromPbAsk(val)
 	}
-	return &ask.IndexSnapshot{
+	return &ask.Index{
 		LastUpdated:        lastUpdated,
 		StorageMedianPrice: reply.GetIndex().StorageMedianPrice,
 		Storage:            storage,

--- a/api/client/asks.go
+++ b/api/client/asks.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/textileio/powergate/index/ask"
 	pb "github.com/textileio/powergate/index/ask/pb"
+	"github.com/textileio/powergate/index/ask/runner"
 )
 
 // Asks provides an API for viewing asks data
@@ -32,7 +33,7 @@ func (a *Asks) Get(ctx context.Context) (*ask.IndexSnapshot, error) {
 }
 
 // Query executes a query to retrieve active Asks
-func (a *Asks) Query(ctx context.Context, query ask.Query) ([]ask.StorageAsk, error) {
+func (a *Asks) Query(ctx context.Context, query runner.Query) ([]ask.StorageAsk, error) {
 	q := &pb.Query{
 		MaxPrice:  query.MaxPrice,
 		PieceSize: query.PieceSize,

--- a/api/client/asks_test.go
+++ b/api/client/asks_test.go
@@ -3,8 +3,8 @@ package client
 import (
 	"testing"
 
-	"github.com/textileio/powergate/index/ask"
 	pb "github.com/textileio/powergate/index/ask/pb"
+	"github.com/textileio/powergate/index/ask/runner"
 )
 
 func TestGetAsks(t *testing.T) {
@@ -23,7 +23,7 @@ func TestQuery(t *testing.T) {
 	a, done := setupAsks(t)
 	defer done()
 
-	_, err := a.Query(ctx, ask.Query{MaxPrice: 5})
+	_, err := a.Query(ctx, runner.Query{MaxPrice: 5})
 	if err != nil {
 		t.Fatalf("failed to call Query: %v", err)
 	}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -38,8 +38,9 @@ import (
 	"github.com/textileio/powergate/gateway"
 	"github.com/textileio/powergate/health"
 	healthRpc "github.com/textileio/powergate/health/rpc"
-	"github.com/textileio/powergate/index/ask"
 	askPb "github.com/textileio/powergate/index/ask/pb"
+	askRpc "github.com/textileio/powergate/index/ask/rpc"
+	ask "github.com/textileio/powergate/index/ask/runner"
 	"github.com/textileio/powergate/index/miner"
 	minerPb "github.com/textileio/powergate/index/miner/pb"
 	"github.com/textileio/powergate/index/slashing"
@@ -71,7 +72,7 @@ type Server struct {
 	ds datastore.TxnDatastore
 
 	ip2l *ip2location.IP2Location
-	ai   *ask.Index
+	ai   *ask.Runner
 	mi   *miner.Index
 	si   *slashing.Index
 	dm   *deals.Module
@@ -277,7 +278,7 @@ func startGRPCServices(server *grpc.Server, webProxy *http.Server, s *Server, ho
 	dealsService := deals.NewService(s.dm)
 	walletService := wallet.NewService(s.wm)
 	reputationService := reputation.NewService(s.rm)
-	askService := ask.NewService(s.ai)
+	askService := askRpc.New(s.ai)
 	minerService := miner.NewService(s.mi)
 	slashingService := slashing.NewService(s.si)
 	ffsService := ffsGrpc.NewService(s.ffsManager, s.hs)

--- a/api/stub/asks.go
+++ b/api/stub/asks.go
@@ -13,7 +13,7 @@ type Asks struct {
 }
 
 // Get returns the current index of available asks
-func (a *Asks) Get(ctx context.Context) (*ask.IndexSnapshot, error) {
+func (a *Asks) Get(ctx context.Context) (*ask.Index, error) {
 	time.Sleep(time.Second * 3)
 	storage := map[string]ask.StorageAsk{
 		"miner1": {
@@ -45,7 +45,7 @@ func (a *Asks) Get(ctx context.Context) (*ask.IndexSnapshot, error) {
 			Expiry:       100,
 		},
 	}
-	return &ask.IndexSnapshot{
+	return &ask.Index{
 		LastUpdated:        time.Now(),
 		StorageMedianPrice: 5000,
 		Storage:            storage,

--- a/api/stub/asks.go
+++ b/api/stub/asks.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/textileio/powergate/index/ask"
+	"github.com/textileio/powergate/index/ask/runner"
 )
 
 // Asks stub
@@ -15,28 +16,28 @@ type Asks struct {
 func (a *Asks) Get(ctx context.Context) (*ask.IndexSnapshot, error) {
 	time.Sleep(time.Second * 3)
 	storage := map[string]ask.StorageAsk{
-		"miner1": ask.StorageAsk{
+		"miner1": {
 			Miner:        "miner1",
 			Price:        5001,
 			MinPieceSize: 1004,
 			Timestamp:    1,
 			Expiry:       100,
 		},
-		"miner2": ask.StorageAsk{
+		"miner2": {
 			Miner:        "miner2",
 			Price:        5002,
 			MinPieceSize: 1004,
 			Timestamp:    2,
 			Expiry:       100,
 		},
-		"miner3": ask.StorageAsk{
+		"miner3": {
 			Miner:        "miner3",
 			Price:        5003,
 			MinPieceSize: 1004,
 			Timestamp:    3,
 			Expiry:       100,
 		},
-		"miner4": ask.StorageAsk{
+		"miner4": {
 			Miner:        "miner4",
 			Price:        5004,
 			MinPieceSize: 1004,
@@ -52,7 +53,7 @@ func (a *Asks) Get(ctx context.Context) (*ask.IndexSnapshot, error) {
 }
 
 // Query executes a query to retrieve active Asks
-func (a *Asks) Query(ctx context.Context, query ask.Query) ([]ask.StorageAsk, error) {
+func (a *Asks) Query(ctx context.Context, query runner.Query) ([]ask.StorageAsk, error) {
 	time.Sleep(time.Second * 3)
 	var asks = []ask.StorageAsk{
 		ask.StorageAsk{

--- a/api/stub/miners.go
+++ b/api/stub/miners.go
@@ -15,7 +15,7 @@ type Miners struct {
 func (a *Miners) Get(ctx context.Context) (*miner.IndexSnapshot, error) {
 	time.Sleep(time.Second * 3)
 	info := map[string]miner.Meta{
-		"miner1": miner.Meta{
+		"miner1": {
 			LastUpdated: time.Now(),
 			UserAgent:   "miner1agent",
 			Location: miner.Location{
@@ -25,7 +25,7 @@ func (a *Miners) Get(ctx context.Context) (*miner.IndexSnapshot, error) {
 			},
 			Online: true,
 		},
-		"miner2": miner.Meta{
+		"miner2": {
 			LastUpdated: time.Now(),
 			UserAgent:   "miner2agent",
 			Location: miner.Location{
@@ -35,7 +35,7 @@ func (a *Miners) Get(ctx context.Context) (*miner.IndexSnapshot, error) {
 			},
 			Online: true,
 		},
-		"miner3": miner.Meta{
+		"miner3": {
 			LastUpdated: time.Now(),
 			UserAgent:   "miner3agent",
 			Location: miner.Location{
@@ -45,7 +45,7 @@ func (a *Miners) Get(ctx context.Context) (*miner.IndexSnapshot, error) {
 			},
 			Online: true,
 		},
-		"miner4": miner.Meta{
+		"miner4": {
 			LastUpdated: time.Now(),
 			UserAgent:   "miner4agent",
 			Location: miner.Location{

--- a/docker/grafana/provisioning/dashboards/TextileFC.json
+++ b/docker/grafana/provisioning/dashboards/TextileFC.json
@@ -183,7 +183,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "container_memory_usage_bytes{name=\"docker_powergate_1\"}",
+          "expr": "container_memory_rss{name=\"docker_powergate_1\"}",
           "interval": "10s",
           "legendFormat": "powergate",
           "refId": "A"

--- a/docker/grafana/provisioning/dashboards/TextileFC.json
+++ b/docker/grafana/provisioning/dashboards/TextileFC.json
@@ -130,7 +130,7 @@
         "#d44a3a"
       ],
       "datasource": null,
-      "format": "decbytes",
+      "format": "percentunit",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,
@@ -144,100 +144,18 @@
         "x": 4,
         "y": 1
       },
-      "id": 6,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
-      "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
-        "lineColor": "rgb(31, 120, 193)",
-        "show": true,
-        "ymax": null,
-        "ymin": null
-      },
-      "tableColumn": "",
-      "targets": [
-        {
-          "expr": "container_memory_rss{name=\"docker_powergate_1\"}",
-          "interval": "10s",
-          "legendFormat": "powergate",
-          "refId": "A"
-        }
-      ],
-      "thresholds": "",
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Memory usage",
-      "type": "singlestat",
-      "valueFontSize": "80%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
-        }
-      ],
-      "valueName": "current"
-    },
-    {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorValue": false,
-      "colors": [
-        "#299c46",
-        "rgba(237, 129, 40, 0.89)",
-        "#d44a3a"
-      ],
-      "datasource": null,
-      "format": "percentunit",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 5,
-        "x": 9,
-        "y": 1
-      },
       "id": 4,
       "interval": null,
       "links": [],
       "mappingType": 1,
       "mappingTypes": [
         {
+          "$$hashKey": "object:226",
           "name": "value to text",
           "value": 1
         },
         {
+          "$$hashKey": "object:227",
           "name": "range to text",
           "value": 2
         }
@@ -258,7 +176,7 @@
       ],
       "sparkline": {
         "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
+        "full": false,
         "lineColor": "rgb(31, 120, 193)",
         "show": true,
         "ymax": null,
@@ -282,6 +200,181 @@
       "valueFontSize": "80%",
       "valueMaps": [
         {
+          "$$hashKey": "object:229",
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "decbytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 9,
+        "y": 1
+      },
+      "id": 6,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "$$hashKey": "object:635",
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "$$hashKey": "object:636",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true,
+        "ymax": null,
+        "ymin": 0
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "container_memory_rss{name=\"docker_powergate_1\"}",
+          "interval": "10s",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Mem RSS",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "$$hashKey": "object:638",
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 1
+      },
+      "id": 41,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "$$hashKey": "object:387",
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "$$hashKey": "object:388",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true,
+        "ymax": null,
+        "ymin": 0
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "textilefc_process_cpu_goroutines{instance=\"powergate:8888\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Go routines",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "$$hashKey": "object:390",
           "op": "=",
           "text": "N/A",
           "value": "null"
@@ -311,9 +404,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
-        "x": 14,
-        "y": 1
+        "w": 4,
+        "x": 0,
+        "y": 5
       },
       "id": 10,
       "interval": null,
@@ -321,10 +414,12 @@
       "mappingType": 1,
       "mappingTypes": [
         {
+          "$$hashKey": "object:1004",
           "name": "value to text",
           "value": 1
         },
         {
+          "$$hashKey": "object:1005",
           "name": "range to text",
           "value": 2
         }
@@ -345,7 +440,7 @@
       ],
       "sparkline": {
         "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
+        "full": false,
         "lineColor": "rgb(31, 120, 193)",
         "show": true,
         "ymax": null,
@@ -367,6 +462,7 @@
       "valueFontSize": "80%",
       "valueMaps": [
         {
+          "$$hashKey": "object:1007",
           "op": "=",
           "text": "N/A",
           "value": "null"
@@ -395,8 +491,8 @@
       "gridPos": {
         "h": 4,
         "w": 5,
-        "x": 19,
-        "y": 1
+        "x": 4,
+        "y": 5
       },
       "id": 8,
       "interval": null,
@@ -404,10 +500,12 @@
       "mappingType": 1,
       "mappingTypes": [
         {
+          "$$hashKey": "object:718",
           "name": "value to text",
           "value": 1
         },
         {
+          "$$hashKey": "object:719",
           "name": "range to text",
           "value": 2
         }
@@ -428,7 +526,7 @@
       ],
       "sparkline": {
         "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
+        "full": false,
         "lineColor": "rgb(31, 120, 193)",
         "show": true,
         "ymax": null,
@@ -438,6 +536,7 @@
       "targets": [
         {
           "expr": "sum(rate(container_network_receive_bytes_total{name=\"docker_powergate_1\"}[1m]))",
+          "interval": "",
           "legendFormat": "docker_powergate",
           "refId": "A"
         }
@@ -450,6 +549,95 @@
       "valueFontSize": "80%",
       "valueMaps": [
         {
+          "$$hashKey": "object:721",
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "format": "bytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 9,
+        "y": 5
+      },
+      "id": 39,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "$$hashKey": "object:166",
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "$$hashKey": "object:167",
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "pluginVersion": "6.7.2",
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true,
+        "ymax": null,
+        "ymin": 0
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "textilefc_process_heap_alloc{instance=\"powergate:8888\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "thresholds": "",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Heap Alloc",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "$$hashKey": "object:169",
           "op": "=",
           "text": "N/A",
           "value": "null"
@@ -464,7 +652,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 9
       },
       "id": 20,
       "panels": [],
@@ -477,7 +665,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 6
+        "y": 10
       },
       "id": 35,
       "options": {
@@ -550,7 +738,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 6
+        "y": 10
       },
       "id": 16,
       "interval": null,
@@ -633,7 +821,7 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 6
+        "y": 10
       },
       "id": 14,
       "interval": null,
@@ -641,10 +829,12 @@
       "mappingType": 1,
       "mappingTypes": [
         {
+          "$$hashKey": "object:838",
           "name": "value to text",
           "value": 1
         },
         {
+          "$$hashKey": "object:839",
           "name": "range to text",
           "value": 2
         }
@@ -666,11 +856,11 @@
       ],
       "sparkline": {
         "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
+        "full": false,
         "lineColor": "rgb(31, 120, 193)",
         "show": true,
         "ymax": null,
-        "ymin": null
+        "ymin": 0
       },
       "tableColumn": "",
       "targets": [
@@ -689,6 +879,7 @@
       "valueFontSize": "80%",
       "valueMaps": [
         {
+          "$$hashKey": "object:841",
           "op": "=",
           "text": "N/A",
           "value": "null"
@@ -718,7 +909,7 @@
         "h": 4,
         "w": 4,
         "x": 12,
-        "y": 6
+        "y": 10
       },
       "id": 22,
       "interval": null,
@@ -726,10 +917,12 @@
       "mappingType": 1,
       "mappingTypes": [
         {
+          "$$hashKey": "object:875",
           "name": "value to text",
           "value": 1
         },
         {
+          "$$hashKey": "object:876",
           "name": "range to text",
           "value": 2
         }
@@ -750,11 +943,11 @@
       ],
       "sparkline": {
         "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
+        "full": false,
         "lineColor": "rgb(31, 120, 193)",
         "show": true,
         "ymax": null,
-        "ymin": null
+        "ymin": 0
       },
       "tableColumn": "",
       "targets": [
@@ -772,6 +965,7 @@
       "valueFontSize": "80%",
       "valueMaps": [
         {
+          "$$hashKey": "object:878",
           "op": "=",
           "text": "N/A",
           "value": "null"
@@ -785,7 +979,7 @@
         "h": 4,
         "w": 4,
         "x": 16,
-        "y": 6
+        "y": 10
       },
       "id": 36,
       "options": {
@@ -843,7 +1037,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 6
+        "y": 10
       },
       "id": 12,
       "links": [],
@@ -906,7 +1100,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 14
       },
       "id": 24,
       "panels": [],
@@ -919,7 +1113,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 11
+        "y": 15
       },
       "id": 26,
       "options": {
@@ -991,7 +1185,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 11
+        "y": 15
       },
       "id": 30,
       "interval": null,
@@ -999,10 +1193,12 @@
       "mappingType": 1,
       "mappingTypes": [
         {
+          "$$hashKey": "object:778",
           "name": "value to text",
           "value": 1
         },
         {
+          "$$hashKey": "object:779",
           "name": "range to text",
           "value": 2
         }
@@ -1023,11 +1219,11 @@
       ],
       "sparkline": {
         "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": true,
+        "full": false,
         "lineColor": "rgb(31, 120, 193)",
         "show": true,
         "ymax": null,
-        "ymin": null
+        "ymin": 0
       },
       "tableColumn": "",
       "targets": [
@@ -1044,6 +1240,7 @@
       "valueFontSize": "80%",
       "valueMaps": [
         {
+          "$$hashKey": "object:781",
           "op": "=",
           "text": "N/A",
           "value": "null"
@@ -1058,7 +1255,7 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 11
+        "y": 15
       },
       "id": 28,
       "links": [],
@@ -1112,7 +1309,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 19
       },
       "id": 32,
       "panels": [],
@@ -1126,7 +1323,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 16
+        "y": 20
       },
       "id": 34,
       "links": [],
@@ -1207,7 +1404,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 16
+        "y": 20
       },
       "id": 37,
       "interval": null,
@@ -1277,7 +1474,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {

--- a/docker/grafana/provisioning/dashboards/TextileFC.json
+++ b/docker/grafana/provisioning/dashboards/TextileFC.json
@@ -1,4 +1,4 @@
-{
+ {
   "annotations": {
     "list": [
       {
@@ -218,7 +218,7 @@
         "#d44a3a"
       ],
       "datasource": null,
-      "format": "decbytes",
+      "format": "bytes",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,
@@ -480,7 +480,7 @@
         "#d44a3a"
       ],
       "datasource": null,
-      "format": "decbytes",
+      "format": "bytes",
       "gauge": {
         "maxValue": 100,
         "minValue": 0,

--- a/exe/cli/cmd/asks_query.go
+++ b/exe/cli/cmd/asks_query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/textileio/powergate/index/ask"
+	askRunner "github.com/textileio/powergate/index/ask/runner"
 )
 
 func init() {
@@ -47,7 +47,7 @@ var queryCmd = &cobra.Command{
 			Fatal(errors.New("pieceSize must be > 0"))
 		}
 
-		q := ask.Query{
+		q := askRunner.Query{
 			MaxPrice:  mp,
 			PieceSize: ps,
 			Limit:     l,

--- a/exe/cli/cmd/deal.go
+++ b/exe/cli/cmd/deal.go
@@ -13,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/textileio/powergate/deals"
-	"github.com/textileio/powergate/index/ask"
+	askRunner "github.com/textileio/powergate/index/ask/runner"
 )
 
 func init() {
@@ -67,7 +67,7 @@ var dealCmd = &cobra.Command{
 		file, err := os.Open(path)
 		checkErr(err)
 
-		q := ask.Query{
+		q := askRunner.Query{
 			MaxPrice:  mp,
 			PieceSize: ps,
 			Limit:     l,

--- a/exe/server/main.go
+++ b/exe/server/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/textileio/powergate/api/server"
 	"github.com/textileio/powergate/util"
+	"go.opencensus.io/plugin/runmetrics"
 )
 
 var (
@@ -137,6 +138,13 @@ func main() {
 }
 
 func setupInstrumentation() *http.Server {
+	err := runmetrics.Enable(runmetrics.RunMetricOptions{
+		EnableCPU:    true,
+		EnableMemory: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
 	pe, err := prometheus.NewExporter(prometheus.Options{
 		Namespace: "textilefc",
 	})

--- a/ffs/minerselector/reptop/reptop.go
+++ b/ffs/minerselector/reptop/reptop.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/textileio/powergate/ffs"
-	"github.com/textileio/powergate/index/ask"
+	askRunner "github.com/textileio/powergate/index/ask/runner"
 	"github.com/textileio/powergate/reputation"
 )
 
@@ -12,14 +12,14 @@ import (
 // miners from a Reputations Module and an Ask Index.
 type RepTop struct {
 	rm *reputation.Module
-	ai *ask.Index
+	ai *askRunner.Runner
 }
 
 var _ ffs.MinerSelector = (*RepTop)(nil)
 
 // New returns a new RetTop instance that uses the specified Reputation Module
 // to select miners and the AskIndex for their epoch prices.
-func New(rm *reputation.Module, ai *ask.Index) *RepTop {
+func New(rm *reputation.Module, ai *askRunner.Runner) *RepTop {
 	return &RepTop{
 		rm: rm,
 		ai: ai,

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -16,7 +16,7 @@ import (
 	assets "github.com/jessevdk/go-assets"
 	"github.com/rs/cors"
 	gincors "github.com/rs/cors/wrapper/gin"
-	"github.com/textileio/powergate/index/ask"
+	askRunner "github.com/textileio/powergate/index/ask/runner"
 	"github.com/textileio/powergate/index/miner"
 	"github.com/textileio/powergate/index/slashing"
 	"github.com/textileio/powergate/reputation"
@@ -46,7 +46,7 @@ func (f *fileSystem) Exists(prefix, path string) bool {
 type Gateway struct {
 	addr             string
 	server           *http.Server
-	askIndex         *ask.Index
+	askIndex         *askRunner.Runner
 	minerIndex       *miner.Index
 	slashingIndex    *slashing.Index
 	reputationModule *reputation.Module
@@ -55,7 +55,7 @@ type Gateway struct {
 // NewGateway returns a new gateway.
 func NewGateway(
 	addr string,
-	askIndex *ask.Index,
+	askIndex *askRunner.Runner,
 	minerIndex *miner.Index,
 	slashingIndex *slashing.Index,
 	reputationModule *reputation.Module,

--- a/index/ask/ask.go
+++ b/index/ask/ask.go
@@ -19,9 +19,9 @@ import (
 )
 
 var (
-	qaRatelim         = 100
+	qaRatelim         = 20
 	qaTimeout         = time.Second * 10
-	qaRefreshInterval = time.Minute
+	qaRefreshInterval = 20 * time.Minute
 	dsIndex           = datastore.NewKey("index")
 
 	log = logging.Logger("index-ask")

--- a/index/ask/internal/metrics/metrics.go
+++ b/index/ask/internal/metrics/metrics.go
@@ -9,11 +9,17 @@ import (
 )
 
 var (
+	// TagAskStatus is a tag for query-ask results.
 	TagAskStatus, _ = tag.NewKey("askstatus")
 
+	// MFullRefreshDuration is a metric for registering the total duration of a full
+	// query ask refresh.
 	MFullRefreshDuration = stats.Int64("askindex/fullrefresh-duration", "Duration of Full StorageAsk refresh", "s")
+	// MFullRefreshProgress is a metric for registering the current progress of
+	// the full scan query ask on miners.
 	MFullRefreshProgress = stats.Float64("askindex/fullrefresh-progress", "Full refresh progress", "By")
-	MAskQueryResult      = stats.Int64("askindex/queryask-result", "Ask query results", "By")
+	// MAskQueryResult is a metric to register the number of results per TagAskStatus status.
+	MAskQueryResult = stats.Int64("askindex/queryask-result", "Ask query results", "By")
 
 	vFullRefreshTime = &view.View{
 		Name:        "askindex/fullrefresh-duration",
@@ -37,6 +43,7 @@ var (
 	views = []*view.View{vFullRefreshTime, vAskQueryResult, vFullRefreshProgress}
 )
 
+// Init register all views.
 func Init() error {
 	if err := view.Register(views...); err != nil {
 		return fmt.Errorf("Failed to register views: %v", err)

--- a/index/ask/internal/metrics/metrics.go
+++ b/index/ask/internal/metrics/metrics.go
@@ -1,42 +1,45 @@
-package ask
+package metrics
 
 import (
+	"fmt"
+
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 )
 
 var (
-	keyAskStatus, _ = tag.NewKey("askstatus")
+	TagAskStatus, _ = tag.NewKey("askstatus")
 
-	mFullRefreshDuration = stats.Int64("askindex/fullrefresh-duration", "Duration of Full StorageAsk refresh", "s")
-	mFullRefreshProgress = stats.Float64("askindex/fullrefresh-progress", "Full refresh progress", "By")
-	mAskQueryResult      = stats.Int64("askindex/queryask-result", "Ask query results", "By")
+	MFullRefreshDuration = stats.Int64("askindex/fullrefresh-duration", "Duration of Full StorageAsk refresh", "s")
+	MFullRefreshProgress = stats.Float64("askindex/fullrefresh-progress", "Full refresh progress", "By")
+	MAskQueryResult      = stats.Int64("askindex/queryask-result", "Ask query results", "By")
 
 	vFullRefreshTime = &view.View{
 		Name:        "askindex/fullrefresh-duration",
-		Measure:     mFullRefreshDuration,
+		Measure:     MFullRefreshDuration,
 		Description: "Full StorageAsk refresh duration",
 		Aggregation: view.LastValue(),
 	}
 	vFullRefreshProgress = &view.View{
 		Name:        "askindex/fullrefresh-progress",
-		Measure:     mFullRefreshProgress,
+		Measure:     MFullRefreshProgress,
 		Description: "Full refresh progress",
 		Aggregation: view.LastValue(),
 	}
 	vAskQueryResult = &view.View{
 		Name:        "askindex/queryask-result",
-		Measure:     mAskQueryResult,
+		Measure:     MAskQueryResult,
 		Description: "Query-Ask results",
-		TagKeys:     []tag.Key{keyAskStatus},
+		TagKeys:     []tag.Key{TagAskStatus},
 		Aggregation: view.LastValue(),
 	}
 	views = []*view.View{vFullRefreshTime, vAskQueryResult, vFullRefreshProgress}
 )
 
-func initMetrics() {
+func Init() error {
 	if err := view.Register(views...); err != nil {
-		log.Fatalf("Failed to register views: %v", err)
+		return fmt.Errorf("Failed to register views: %v", err)
 	}
+	return nil
 }

--- a/index/ask/internal/store/store.go
+++ b/index/ask/internal/store/store.go
@@ -25,7 +25,7 @@ func New(ds datastore.Datastore) *Store {
 }
 
 // Save persist the index into the datastore.
-func (s *Store) Save(idx ask.IndexSnapshot) error {
+func (s *Store) Save(idx ask.Index) error {
 	buf, err := json.Marshal(idx)
 	if err != nil {
 		return fmt.Errorf("marshaling new index: %s", err)
@@ -38,17 +38,17 @@ func (s *Store) Save(idx ask.IndexSnapshot) error {
 
 // Get returns the last saved ask index. If no ask index was persisted,
 // it returns an valid empty index.
-func (s *Store) Get() (ask.IndexSnapshot, error) {
+func (s *Store) Get() (ask.Index, error) {
 	buf, err := s.ds.Get(dsKey)
 	if err != nil {
 		if err == datastore.ErrNotFound {
-			return ask.IndexSnapshot{Storage: make(map[string]ask.StorageAsk)}, nil
+			return ask.Index{Storage: make(map[string]ask.StorageAsk)}, nil
 		}
-		return ask.IndexSnapshot{}, err
+		return ask.Index{}, err
 	}
-	idx := ask.IndexSnapshot{}
+	idx := ask.Index{}
 	if err = json.Unmarshal(buf, &idx); err != nil {
-		return ask.IndexSnapshot{}, err
+		return ask.Index{}, err
 	}
 	return idx, nil
 }

--- a/index/ask/internal/store/store.go
+++ b/index/ask/internal/store/store.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/textileio/powergate/index/ask"
+)
+
+var (
+	dsKey = datastore.NewKey("index")
+)
+
+// Store persists ask index into a datastore.
+type Store struct {
+	ds datastore.Datastore
+}
+
+// New returns a new store for ask index.
+func New(ds datastore.Datastore) *Store {
+	return &Store{
+		ds: ds,
+	}
+}
+
+// Save persist the index into the datastore.
+func (s *Store) Save(idx ask.IndexSnapshot) error {
+	buf, err := json.Marshal(idx)
+	if err != nil {
+		return fmt.Errorf("marshaling new index: %s", err)
+	}
+	if err = s.ds.Put(dsKey, buf); err != nil {
+		return fmt.Errorf("saving to datastore: %s", err)
+	}
+	return nil
+}
+
+// Get returns the last saved ask index. If no ask index was persisted,
+// it returns an valid empty index.
+func (s *Store) Get() (ask.IndexSnapshot, error) {
+	buf, err := s.ds.Get(dsKey)
+	if err != nil {
+		if err == datastore.ErrNotFound {
+			return ask.IndexSnapshot{Storage: make(map[string]ask.StorageAsk)}, nil
+		}
+		return ask.IndexSnapshot{}, err
+	}
+	idx := ask.IndexSnapshot{}
+	if err = json.Unmarshal(buf, &idx); err != nil {
+		return ask.IndexSnapshot{}, err
+	}
+	return idx, nil
+}

--- a/index/ask/rpc/rpc.go
+++ b/index/ask/rpc/rpc.go
@@ -14,14 +14,14 @@ type Service struct {
 	index *runner.Runner
 }
 
-// NewService is a helper to create a new Service
+// New is a helper to create a new Service.
 func New(ai *runner.Runner) *Service {
 	return &Service{
 		index: ai,
 	}
 }
 
-// Get calls askIndex.Get
+// Get returns the current Ask Storage index.
 func (s *Service) Get(ctx context.Context, req *pb.GetRequest) (*pb.GetReply, error) {
 	index := s.index.Get()
 	storage := make(map[string]*pb.StorageAsk, len(index.Storage))
@@ -42,7 +42,7 @@ func (s *Service) Get(ctx context.Context, req *pb.GetRequest) (*pb.GetReply, er
 	return &pb.GetReply{Index: pbIndex}, nil
 }
 
-// Query calls askIndex.Query
+// Query executes a query on the current Ask Storage index.
 func (s *Service) Query(ctx context.Context, req *pb.QueryRequest) (*pb.QueryReply, error) {
 	q := runner.Query{
 		MaxPrice:  req.GetQuery().GetMaxPrice(),

--- a/index/ask/rpc/rpc.go
+++ b/index/ask/rpc/rpc.go
@@ -1,20 +1,21 @@
-package ask
+package rpc
 
 import (
 	"context"
 
 	pb "github.com/textileio/powergate/index/ask/pb"
+	"github.com/textileio/powergate/index/ask/runner"
 )
 
 // Service implements the gprc service
 type Service struct {
 	pb.UnimplementedAPIServer
 
-	index *Index
+	index *runner.Runner
 }
 
 // NewService is a helper to create a new Service
-func NewService(ai *Index) *Service {
+func New(ai *runner.Runner) *Service {
 	return &Service{
 		index: ai,
 	}
@@ -43,7 +44,7 @@ func (s *Service) Get(ctx context.Context, req *pb.GetRequest) (*pb.GetReply, er
 
 // Query calls askIndex.Query
 func (s *Service) Query(ctx context.Context, req *pb.QueryRequest) (*pb.QueryReply, error) {
-	q := Query{
+	q := runner.Query{
 		MaxPrice:  req.GetQuery().GetMaxPrice(),
 		PieceSize: req.GetQuery().GetPieceSize(),
 		Limit:     int(req.GetQuery().GetLimit()),

--- a/index/ask/runner/runner.go
+++ b/index/ask/runner/runner.go
@@ -248,17 +248,18 @@ func generateIndex(ctx context.Context, api *apistruct.FullNodeStruct) (ask.Inde
 func getMinerStorageAsk(ctx context.Context, api *apistruct.FullNodeStruct, addr address.Address) (ask.StorageAsk, bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, qaTimeout)
 	defer cancel()
+	power, err := api.StateMinerPower(ctx, addr, types.EmptyTSK)
+	if err != nil {
+		return ask.StorageAsk{}, false, fmt.Errorf("getting power %s: %s", addr, err)
+	}
+	if power.MinerPower.RawBytePower.IsZero() {
+		return ask.StorageAsk{}, false, nil
+	}
 	mi, err := api.StateMinerInfo(ctx, addr, types.EmptyTSK)
 	if err != nil {
 		return ask.StorageAsk{}, false, fmt.Errorf("getting miner %s info: %s", addr, err)
 	}
-	minfo, err := api.StateMinerPower(ctx, addr, types.EmptyTSK)
-	if err != nil {
-		return ask.StorageAsk{}, false, fmt.Errorf("getting power %s: %s", addr, err)
-	}
-	if minfo.MinerPower.RawBytePower.IsZero() {
-		return ask.StorageAsk{}, false, nil
-	}
+
 	sask, err := api.ClientQueryAsk(ctx, mi.PeerId, addr)
 	if err != nil {
 		return ask.StorageAsk{}, false, nil

--- a/index/ask/runner/runner.go
+++ b/index/ask/runner/runner.go
@@ -198,6 +198,9 @@ func generateIndex(ctx context.Context, api *apistruct.FullNodeStruct) (ask.Inde
 	var lock sync.Mutex
 	newAsks := make(map[string]ask.StorageAsk)
 	for i, addr := range addrs {
+		if ctx.Err() != nil {
+			break
+		}
 		rateLim <- struct{}{}
 		go func(addr address.Address) {
 			defer func() { <-rateLim }()
@@ -222,10 +225,8 @@ func generateIndex(ctx context.Context, api *apistruct.FullNodeStruct) (ask.Inde
 		rateLim <- struct{}{}
 	}
 
-	select {
-	case <-ctx.Done():
+	if ctx.Err() != nil {
 		return ask.Index{}, nil, fmt.Errorf("refresh was canceled")
-	default:
 	}
 
 	stats.Record(context.Background(), metrics.MFullRefreshProgress.M(1))

--- a/index/ask/runner/runner_test.go
+++ b/index/ask/runner/runner_test.go
@@ -1,4 +1,4 @@
-package ask
+package runner
 
 import (
 	"context"

--- a/index/ask/runner/runner_test.go
+++ b/index/ask/runner/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	logging "github.com/ipfs/go-log/v2"
+	"github.com/textileio/powergate/index/ask"
 	"github.com/textileio/powergate/tests"
 )
 
@@ -23,7 +24,7 @@ func TestFreshBuild(t *testing.T) {
 	ctx := context.Background()
 	dnet, _, miners := tests.CreateLocalDevnet(t, 1)
 
-	index, err := generateIndex(ctx, dnet)
+	index, _, err := generateIndex(ctx, dnet)
 	checkErr(t, err)
 
 	// We should have storage info about every miner in devnet
@@ -44,15 +45,15 @@ func TestFreshBuild(t *testing.T) {
 
 func TestQueryAsk(t *testing.T) {
 	t.Parallel()
-	dm := Index{}
-	dm.priceOrderedCache = []*StorageAsk{
+	dm := Runner{}
+	dm.orderedAsks = []*ask.StorageAsk{
 		{Price: uint64(20), MinPieceSize: 128, Miner: "t01"},
 		{Price: uint64(30), MinPieceSize: 64, Miner: "t02"},
 		{Price: uint64(40), MinPieceSize: 256, Miner: "t03"},
 		{Price: uint64(50), MinPieceSize: 16, Miner: "t04"},
 	}
 
-	facr := []StorageAsk{
+	facr := []ask.StorageAsk{
 		{Price: 20, MinPieceSize: 128, Miner: "t01"},
 		{Price: 30, MinPieceSize: 64, Miner: "t02"},
 		{Price: 40, MinPieceSize: 256, Miner: "t03"},
@@ -62,13 +63,13 @@ func TestQueryAsk(t *testing.T) {
 	tests := []struct {
 		name   string
 		q      Query
-		expect []StorageAsk
+		expect []ask.StorageAsk
 	}{
 		{name: "All", q: Query{}, expect: facr},
-		{name: "LeqPrice35", q: Query{MaxPrice: 35}, expect: []StorageAsk{facr[0], facr[1]}},
+		{name: "LeqPrice35", q: Query{MaxPrice: 35}, expect: []ask.StorageAsk{facr[0], facr[1]}},
 		{name: "LeqPrice50", q: Query{MaxPrice: 50}, expect: facr},
-		{name: "LeqPrice40Piece96", q: Query{MaxPrice: 35, PieceSize: 96}, expect: []StorageAsk{facr[1]}},
-		{name: "AllLimit2Offset1", q: Query{Limit: 2, Offset: 1}, expect: []StorageAsk{facr[1], facr[2]}},
+		{name: "LeqPrice40Piece96", q: Query{MaxPrice: 35, PieceSize: 96}, expect: []ask.StorageAsk{facr[1]}},
+		{name: "AllLimit2Offset1", q: Query{Limit: 2, Offset: 1}, expect: []ask.StorageAsk{facr[1], facr[2]}},
 	}
 
 	for _, tt := range tests {

--- a/index/ask/types.go
+++ b/index/ask/types.go
@@ -11,14 +11,6 @@ type IndexSnapshot struct {
 	Storage            map[string]StorageAsk
 }
 
-// Query specifies filtering and paging data to retrieve active Asks
-type Query struct {
-	MaxPrice  uint64
-	PieceSize uint64
-	Limit     int
-	Offset    int
-}
-
 // StorageAsk has information about an active ask from a storage miner
 type StorageAsk struct {
 	Miner        string

--- a/index/ask/types.go
+++ b/index/ask/types.go
@@ -4,8 +4,8 @@ import (
 	"time"
 )
 
-// IndexSnapshot contains Ask information from markets
-type IndexSnapshot struct {
+// Index contains Ask information from markets
+type Index struct {
 	LastUpdated        time.Time
 	StorageMedianPrice uint64
 	Storage            map[string]StorageAsk

--- a/index/miner/meta.go
+++ b/index/miner/meta.go
@@ -45,8 +45,10 @@ func (mi *Index) metaWorker() {
 			// doing a merge. Will depend if this too slow, but might not be the case
 			mi.lock.Lock()
 			addrs := make([]string, 0, len(mi.index.Chain.Power))
-			for addr := range mi.index.Chain.Power {
-				addrs = append(addrs, addr)
+			for addr, power := range mi.index.Chain.Power {
+				if power.Power > 0 {
+					addrs = append(addrs, addr)
+				}
 			}
 			mi.lock.Unlock()
 			newIndex, err := updateMetaIndex(mi.ctx, mi.api, mi.h, mi.lr, addrs)

--- a/reputation/reputation.go
+++ b/reputation/reputation.go
@@ -12,6 +12,7 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/textileio/powergate/index/ask"
+	askRunner "github.com/textileio/powergate/index/ask/runner"
 	"github.com/textileio/powergate/index/miner"
 	"github.com/textileio/powergate/index/slashing"
 	"github.com/textileio/powergate/reputation/internal/source"
@@ -30,7 +31,7 @@ type Module struct {
 
 	mi *miner.Index
 	si *slashing.Index
-	ai *ask.Index
+	ai *askRunner.Runner
 
 	lockIndex sync.Mutex
 	mIndex    miner.IndexSnapshot
@@ -52,7 +53,7 @@ type MinerScore struct {
 }
 
 // New returns a new reputation Module
-func New(ds datastore.TxnDatastore, mi *miner.Index, si *slashing.Index, ai *ask.Index) *Module {
+func New(ds datastore.TxnDatastore, mi *miner.Index, si *slashing.Index, ai *askRunner.Runner) *Module {
 	ctx, cancel := context.WithCancel(context.Background())
 	rm := &Module{
 		ds: ds,

--- a/reputation/reputation.go
+++ b/reputation/reputation.go
@@ -36,7 +36,7 @@ type Module struct {
 	lockIndex sync.Mutex
 	mIndex    miner.IndexSnapshot
 	sIndex    slashing.IndexSnapshot
-	aIndex    ask.IndexSnapshot
+	aIndex    ask.Index
 
 	lockScores sync.Mutex
 	rebuild    chan struct{}
@@ -231,7 +231,7 @@ func (rm *Module) indexBuilder() {
 }
 
 // calculateScore calculates the score for a miner
-func calculateScore(addr string, mi miner.IndexSnapshot, si slashing.IndexSnapshot, ai ask.IndexSnapshot, ss []source.Source) MinerScore {
+func calculateScore(addr string, mi miner.IndexSnapshot, si slashing.IndexSnapshot, ai ask.Index, ss []source.Source) MinerScore {
 	power := mi.Chain.Power[addr]
 	powerScore := power.Relative
 


### PR DESCRIPTION
- Medium refactor in `index/ask`.
- Only query-ask miners with power > 0.
- Only get metadata info with miners with power > 0.
- Expose Go memstats metrics and adds the to grafana dashboard.

Since there're many movements and renames, I'll leave comments about main points.

Closes #406
Closes #407