### PR TITLE
compose: Use unreversed Lotus Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: exe/server/Dockerfile
+          dockerfile: cmd/powd/Dockerfile
           repository: textile/powergate
           tag_with_ref: true
           tag_with_sha: true

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     image: textile/lotus:75041b9
     volumes:
       - textile-fc-lotus:/data
-    enviroment:
+    environment:
       - LOTUS_API_LISTENADDRESS=/ip4/0.0.0.0/tcp/1234/http
     ports:
       - 1234:1234

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       - ipfs
       - lotus
     environment:
-      - POWD_LOTUSHOST=/dns4/lotus/tcp/1235
+      - POWD_LOTUSHOST=/dns4/lotus/tcp/1234
       - POWD_IPFSAPIADDR=/dns4/ipfs/tcp/5001
       - POWD_LOTUSTOKENFILE=/root/lotus/.lotus/token
       - POWD_REPOPATH=/root/powergate/.powergate
@@ -31,11 +31,13 @@ services:
       - textile-fc-lotus:/root/lotus
   
   lotus:
-    image: textile/lotus:af1d545
+    image: textile/lotus:75041b9
     volumes:
       - textile-fc-lotus:/data
+    enviroment:
+      - LOTUS_API_LISTENADDRESS=/ip4/0.0.0.0/tcp/1234/http
     ports:
-      - 1235:1235
+      - 1234:1234
       - 5678:5678
     restart: unless-stopped
 


### PR DESCRIPTION
Now that we can tune Lotus with environment variables, I can set easily the listening address to be different than `127.0.0.1`. This means that `textile/lotus-build` doesn't need now a reverse-proxy, so that build process became much simpler.

Basically it runs the Docker build for a pristine Lotus without the reverse proxy, and leave to the runner specify `LOTUS_API_LISTENADDRESS` if want's to bind to `0.0.0.0`.

This also allows to modify the CMD of the run more easily if other non-default flags want to be passed into the Lotus run on start (**e.g: `lotus daemon --import-chain`**, or whatever flag).

More info [in changed files of this PR](https://github.com/textileio/lotus-build/pull/5/files). From the Powergate side, it's basically updating to the newer image and specifying the desired listen-address.