### PR TITLE
ffs/manager: configurable persisted default CidConfig & better integrationtest setup 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build-powbench:
 .PHONY: build-powbench
 
 test:
-	go test -short -p 4 -race -timeout 30m ./... 
+	go test -short -parallel 4 -race -timeout 30m ./... 
 .PHONY: test
 
 clean-protos:

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Join us on our [public Slack channel](https://slack.textile.io/) for news, discu
 ## Table of Contents
 
 -   [Design](#design)
--   [API + CLI](#api&CLI)
+-   [API + CLI](#api-&-CLI)
 -   [Installation](#installation)
--   [Devnet mode](#devnetmode)
--   [Production setup](#productionsetup)
+-   [Devnet mode](#devnet-mode)
+-   [Production setup](#production-setup)
 -   [Test](#tests)
 -   [Benchmark](#benchmark)
 -   [Contributing](#contributing)

--- a/README.md
+++ b/README.md
@@ -15,11 +15,10 @@ Join us on our [public Slack channel](https://slack.textile.io/) for news, discu
 ## Table of Contents
 
 -   [Design](#design)
--   [API + CLI](#api-&-CLI)
 -   [Installation](#installation)
 -   [Devnet mode](#devnet-mode)
 -   [Production setup](#production-setup)
--   [Test](#tests)
+-   [Tests](#tests)
 -   [Benchmark](#benchmark)
 -   [Contributing](#contributing)
 -   [Changelog](#changelog)
@@ -193,7 +192,7 @@ Remember that you should wait for _Lotus_ to be fully-synced which might take a 
 
 We will soon provide other non-contanerized setups, but most of the wiring can be auto-explained by the `docker/docker-compose.yaml` file.
 
-## Test
+## Tests
 We have a big set of tests for covering most important Powergate features.
 
 For integration tests, we leverage our `textileio/lotus-devnet` configured with 2Kib sectors to provide fast iteration and CI runs.

--- a/ffs/cidlogger/cidlogger.go
+++ b/ffs/cidlogger/cidlogger.go
@@ -48,6 +48,7 @@ func New(ds datastore.Datastore) *CidLogger {
 // Log logs a log entry for a Cid. The ctx can contain an optional ffs.CtxKeyJid to add
 // additional metadata about the log entry being part of a Job execution.
 func (cl *CidLogger) Log(ctx context.Context, c cid.Cid, format string, a ...interface{}) {
+	log.Infof(format, a...)
 	jid := ffs.EmptyJobID
 	if ctxjid, ok := ctx.Value(ffs.CtxKeyJid).(ffs.JobID); ok {
 		jid = ctxjid

--- a/ffs/cidlogger/cidlogger.go
+++ b/ffs/cidlogger/cidlogger.go
@@ -48,7 +48,6 @@ func New(ds datastore.Datastore) *CidLogger {
 // Log logs a log entry for a Cid. The ctx can contain an optional ffs.CtxKeyJid to add
 // additional metadata about the log entry being part of a Job execution.
 func (cl *CidLogger) Log(ctx context.Context, c cid.Cid, format string, a ...interface{}) {
-	log.Infof(format, a...)
 	jid := ffs.EmptyJobID
 	if ctxjid, ok := ctx.Value(ffs.CtxKeyJid).(ffs.JobID); ok {
 		jid = ctxjid

--- a/ffs/coreipfs/coreipfs.go
+++ b/ffs/coreipfs/coreipfs.go
@@ -128,6 +128,11 @@ func (ci *CoreIpfs) Replace(ctx context.Context, c1 cid.Cid, c2 cid.Cid) (int, e
 	if err != nil {
 		return 0, fmt.Errorf("getting stats of cid %s: %s", c2, err)
 	}
+	ci.lock.Lock()
+	delete(ci.pinset, c1)
+	ci.pinset[c2] = struct{}{}
+	ci.lock.Unlock()
+
 	return stat.Size(), nil
 }
 

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1047,9 +1047,7 @@ func TestDoubleReplace(t *testing.T) {
 	// Test the same workflow in different APIs instaneces,
 	// but same hot & cold layer.
 	testAddThenReplace()
-	fmt.Println("First finished good!")
 	testAddThenReplace()
-	fmt.Println("All good")
 }
 
 func TestRemove(t *testing.T) {

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -514,6 +514,7 @@ func TestFilecoinMaxPriceFilter(t *testing.T) {
 	defer closeManager()
 	_, auth, err := manager.Create(context.Background())
 	require.NoError(t, err)
+	time.Sleep(time.Second * 3) // Wait for funding txn.
 	fapi, err := manager.GetByAuthToken(auth)
 	require.NoError(t, err)
 

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -483,6 +483,7 @@ func TestFilecoinCountryFilter(t *testing.T) {
 	manager, closeManager := newFFSManager(t, ds, client, addr, ms, ipfs)
 	defer closeManager()
 	_, auth, err := manager.Create(context.Background())
+	require.NoError(t, err)
 	time.Sleep(time.Second * 3)
 	fapi, err := manager.GetByAuthToken(auth)
 	require.NoError(t, err)

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1015,25 +1015,11 @@ func TestPushCidReplace(t *testing.T) {
 
 func TestDoubleReplace(t *testing.T) {
 	t.Parallel()
-
-	// <boilerplate>
-	ipfs, ipfsDockerMAddr := createIPFS(t)
 	ds := tests.NewTxMapDatastore()
-	waddr, client, ms := newDevnet(t, 1, ipfsDockerMAddr)
-	dm, err := deals.New(client)
-	require.Nil(t, err)
-	fchain := filchain.New(client)
-	l := cidlogger.New(txndstr.Wrap(ds, "ffs/cidlogger"))
-	cl := filcold.New(ms, dm, ipfs, fchain, l)
-	hl := coreipfs.New(ipfs, l)
-	sched := scheduler.New(txndstr.Wrap(ds, "ffs/scheduler"), l, hl, cl)
-	wm, err := wallet.New(client, waddr, *big.NewInt(iWalletBal))
-	require.Nil(t, err)
-	// </boilerplate>
-
-	// Create a manager
-	m, err := manager.New(ds, wm, sched)
-	require.NoError(t, err)
+	ipfs, ipfsMAddr := createIPFS(t)
+	addr, client, ms := newDevnet(t, 1, ipfsMAddr)
+	m, closeManager := newFFSManager(t, ds, client, addr, ms, ipfs)
+	defer closeManager()
 
 	// This will ask for a new API to the manager, and do a replace. Always the same replace.
 	testAddThenReplace := func() {

--- a/ffs/manager/manager.go
+++ b/ffs/manager/manager.go
@@ -97,6 +97,8 @@ func (m *Manager) Create(ctx context.Context) (ffs.APIID, string, error) {
 	return fapi.ID(), auth, nil
 }
 
+// SetDefaultConfig sets the default CidConfig to be set as default to newly created
+// FFS instances.
 func (m *Manager) SetDefaultConfig(dc ffs.DefaultConfig) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/ffs/manager/manager.go
+++ b/ffs/manager/manager.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -19,10 +20,29 @@ var (
 	// ErrAuthTokenNotFound returns when an auth-token doesn't exist.
 	ErrAuthTokenNotFound = errors.New("auth token not found")
 
-	createDefConfig sync.Once
-	defCidConfig    ffs.DefaultConfig
-
 	log = logging.Logger("ffs-manager")
+
+	// zeroConfig is a safe-initial value for a default
+	// CidConfig for a manager. A newly (not re-loaded) created
+	// manager will have this configuration by default. It can be
+	// later changed with the Get/Set APIs. A re-loaded manager will
+	// recover its laste configured CidConfig from the datastore.
+	zeroConfig = ffs.DefaultConfig{
+		Hot: ffs.HotConfig{
+			Enabled: true,
+			Ipfs: ffs.IpfsConfig{
+				AddTimeout: 30,
+			},
+		},
+		Cold: ffs.ColdConfig{
+			Enabled: true,
+			Filecoin: ffs.FilConfig{
+				RepFactor:    1,
+				DealDuration: 1000,
+			},
+		},
+	}
+	dsDefaultCidConfigKey = datastore.NewKey("defaultcidconfig")
 )
 
 // Manager creates Api instances, or loads existing ones them from an auth-token.
@@ -30,22 +50,28 @@ type Manager struct {
 	wm    ffs.WalletManager
 	sched *scheduler.Scheduler
 
-	lock      sync.Mutex
-	ds        datastore.Datastore
-	auth      *auth.Auth
-	instances map[ffs.APIID]*api.API
+	lock          sync.Mutex
+	ds            datastore.Datastore
+	auth          *auth.Auth
+	instances     map[ffs.APIID]*api.API
+	defaultConfig ffs.DefaultConfig
 
 	closed bool
 }
 
 // New returns a new Manager.
 func New(ds datastore.Datastore, wm ffs.WalletManager, sched *scheduler.Scheduler) (*Manager, error) {
+	cidConfig, err := loadDefaultCidConfig(ds)
+	if err != nil {
+		return nil, fmt.Errorf("loading default cidconfig: %s", err)
+	}
 	return &Manager{
-		auth:      auth.New(namespace.Wrap(ds, datastore.NewKey("auth"))),
-		ds:        ds,
-		wm:        wm,
-		sched:     sched,
-		instances: make(map[ffs.APIID]*api.API),
+		auth:          auth.New(namespace.Wrap(ds, datastore.NewKey("auth"))),
+		ds:            ds,
+		wm:            wm,
+		sched:         sched,
+		instances:     make(map[ffs.APIID]*api.API),
+		defaultConfig: cidConfig,
 	}, nil
 }
 
@@ -54,27 +80,9 @@ func (m *Manager) Create(ctx context.Context) (ffs.APIID, string, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	createDefConfig.Do(func() {
-		defCidConfig = ffs.DefaultConfig{
-			Hot: ffs.HotConfig{
-				Enabled: true,
-				Ipfs: ffs.IpfsConfig{
-					AddTimeout: 30,
-				},
-			},
-			Cold: ffs.ColdConfig{
-				Enabled: true,
-				Filecoin: ffs.FilConfig{
-					RepFactor:    1,
-					DealDuration: 1000,
-				},
-			},
-		}
-	})
-
 	log.Info("creating instance")
 	iid := ffs.NewAPIID()
-	fapi, err := api.New(ctx, namespace.Wrap(m.ds, datastore.NewKey("api/"+iid.String())), iid, m.sched, m.wm, defCidConfig)
+	fapi, err := api.New(ctx, namespace.Wrap(m.ds, datastore.NewKey("api/"+iid.String())), iid, m.sched, m.wm, m.defaultConfig)
 	if err != nil {
 		return ffs.EmptyInstanceID, "", fmt.Errorf("creating new instance: %s", err)
 	}
@@ -87,6 +95,15 @@ func (m *Manager) Create(ctx context.Context) (ffs.APIID, string, error) {
 	m.instances[iid] = fapi
 
 	return fapi.ID(), auth, nil
+}
+
+func (m *Manager) SetDefaultConfig(dc ffs.DefaultConfig) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if err := m.saveDefaultConfig(dc); err != nil {
+		return fmt.Errorf("persisting default configuration: %s", err)
+	}
+	return nil
 }
 
 // List returns a list of all existing API instances.
@@ -127,6 +144,14 @@ func (m *Manager) GetByAuthToken(token string) (*api.API, error) {
 	return i, nil
 }
 
+// GetDefaultConfig returns the current default CidConfig used
+// for newly created FFS instances.
+func (m *Manager) GetDefaultConfig() ffs.DefaultConfig {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.defaultConfig
+}
+
 // Close closes a Manager and consequently all loaded instances.
 func (m *Manager) Close() error {
 	m.lock.Lock()
@@ -141,4 +166,34 @@ func (m *Manager) Close() error {
 	}
 	m.closed = true
 	return nil
+}
+
+// saveDefaultConfig persists a new default configuration and updates
+// the cached value. This method must be guarded.
+func (m *Manager) saveDefaultConfig(dc ffs.DefaultConfig) error {
+	buf, err := json.Marshal(dc)
+	if err != nil {
+		return fmt.Errorf("marshaling default config: %s", err)
+	}
+	if err := m.ds.Put(dsDefaultCidConfigKey, buf); err != nil {
+		return fmt.Errorf("saving default config to datastore: %s", err)
+	}
+	m.defaultConfig = dc
+	return nil
+}
+
+func loadDefaultCidConfig(ds datastore.Datastore) (ffs.DefaultConfig, error) {
+	d, err := ds.Get(dsDefaultCidConfigKey)
+	if err == datastore.ErrNotFound {
+		return zeroConfig, nil
+	}
+	if err != nil {
+		return ffs.DefaultConfig{}, fmt.Errorf("get from datastore: %s", err)
+	}
+
+	var defaultConfig ffs.DefaultConfig
+	if err := json.Unmarshal(d, &defaultConfig); err != nil {
+		return ffs.DefaultConfig{}, fmt.Errorf("unmarshaling default cidconfig: %s", err)
+	}
+	return defaultConfig, nil
 }

--- a/ffs/manager/manager_test.go
+++ b/ffs/manager/manager_test.go
@@ -96,6 +96,35 @@ func TestGetByAuthToken(t *testing.T) {
 	})
 }
 
+func TestDefaultConfig(t *testing.T) {
+	t.Parallel()
+	ds := tests.NewTxMapDatastore()
+	m, cls := newManager(t, ds)
+	defer cls()
+
+	// A newly created manager must have
+	// the zeroConfig defined value.
+	c := m.GetDefaultConfig()
+	require.Equal(t, zeroConfig, c)
+
+	// Change the default config and test.
+	c.Hot.Enabled = false
+	c.Repairable = true
+	err := m.SetDefaultConfig(c)
+	require.NoError(t, err)
+	c2 := m.GetDefaultConfig()
+	require.Equal(t, c, c2)
+	cls()
+
+	// Re-open manager, and check that
+	// the default config was the last
+	// saved one, and not zeroConfig.
+	m, cls = newManager(t, ds)
+	defer cls()
+	c3 := m.GetDefaultConfig()
+	require.Equal(t, c, c3)
+}
+
 func newManager(t *testing.T, ds datastore.TxnDatastore) (*Manager, func()) {
 	client, addr, _ := tests.CreateLocalDevnet(t, 1)
 	wm, err := wallet.New(client, addr, *big.NewInt(4000000000))


### PR DESCRIPTION
In this PR three things are addressed:
- Closes #426 
- Fixes a bug regarding Replace on HotStorage not updating the cached pinset.
- Reestructure integrationtest helpers better. 