### PR TITLE
devnet: not use volumes && linters rise bar

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-contrib/golangci-lint@v1
+      - uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.27
   spell-check:
      name: spell-check
      runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,30 +3,31 @@ linters-settings:
     locale: US
 
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  # disable-all: true
   enable:
     - golint
     - misspell
-
-  # don't enable:
-  # - gochecknoglobals
-  # - gocognit
-  # - godox
-  # - maligned
-  # - prealloc
+    - gocyclo
+    - bodyclose
+    - unconvert
+    - goconst
+    - goimports
+    - unparam
+    - whitespace
+    - godot
 
 issues:
   exclude-use-default: false
+
+  exclude-rules:
+    - path: cmd/powbench/runner/runner_test.go
+      linters:
+        - unused
 
 run:
   timeout: 30m
   skip-files:
     - gateway/assets.go
 
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.23.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.27.x # use the fixed version to not introduce new linters unexpectedly
     

--- a/api/client/asks.go
+++ b/api/client/asks.go
@@ -9,12 +9,12 @@ import (
 	"github.com/textileio/powergate/index/ask/runner"
 )
 
-// Asks provides an API for viewing asks data
+// Asks provides an API for viewing asks data.
 type Asks struct {
 	client rpc.RPCServiceClient
 }
 
-// Get returns the current index of available asks
+// Get returns the current index of available asks.
 func (a *Asks) Get(ctx context.Context) (*ask.Index, error) {
 	reply, err := a.client.Get(ctx, &rpc.GetRequest{})
 	if err != nil {
@@ -32,7 +32,7 @@ func (a *Asks) Get(ctx context.Context) (*ask.Index, error) {
 	}, nil
 }
 
-// Query executes a query to retrieve active Asks
+// Query executes a query to retrieve active Asks.
 func (a *Asks) Query(ctx context.Context, query runner.Query) ([]ask.StorageAsk, error) {
 	q := &rpc.Query{
 		MaxPrice:  query.MaxPrice,

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Client provides the client api
+// Client provides the client api.
 type Client struct {
 	Asks       *Asks
 	Miners     *Miners
@@ -33,30 +33,30 @@ type Client struct {
 
 type ctxKey string
 
-// AuthKey is the key that should be used to set the auth token in a Context
+// AuthKey is the key that should be used to set the auth token in a Context.
 const AuthKey = ctxKey("ffstoken")
 
-// TokenAuth provides token based auth
+// TokenAuth provides token based auth.
 type TokenAuth struct {
 	secure bool
 }
 
-// GetRequestMetadata returns request metadata that includes the auth token
+// GetRequestMetadata returns request metadata that includes the auth token.
 func (t TokenAuth) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
 	md := map[string]string{}
-	token, ok := ctx.Value(ctxKey(AuthKey)).(string)
+	token, ok := ctx.Value(AuthKey).(string)
 	if ok && token != "" {
 		md["X-ffs-Token"] = token
 	}
 	return md, nil
 }
 
-// RequireTransportSecurity specifies if the connection should be secure
+// RequireTransportSecurity specifies if the connection should be secure.
 func (t TokenAuth) RequireTransportSecurity() bool {
 	return t.secure
 }
 
-// NewClient creates a client
+// NewClient creates a client.
 func NewClient(ma multiaddr.Multiaddr, opts ...grpc.DialOption) (*Client, error) {
 	addr, err := util.TCPAddrFromMultiAddr(ma)
 	if err != nil {
@@ -81,7 +81,7 @@ func NewClient(ma multiaddr.Multiaddr, opts ...grpc.DialOption) (*Client, error)
 	return client, nil
 }
 
-// Close closes the client's grpc connection and cancels any active requests
+// Close closes the client's grpc connection and cancels any active requests.
 func (c *Client) Close() error {
 	return c.conn.Close()
 }

--- a/api/client/deals.go
+++ b/api/client/deals.go
@@ -13,19 +13,19 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// Deals provides an API for managing deals and storing data
+// Deals provides an API for managing deals and storing data.
 type Deals struct {
 	client rpc.RPCServiceClient
 }
 
-// WatchEvent is used to send data or error values for Watch
+// WatchEvent is used to send data or error values for Watch.
 type WatchEvent struct {
 	Deal deals.DealInfo
 	Err  error
 }
 
 // Store creates a proposal deal for data using wallet addr to all miners indicated
-// by dealConfigs for duration epochs
+// by dealConfigs for duration epochs.
 func (d *Deals) Store(ctx context.Context, addr string, data io.Reader, dealConfigs []deals.StorageDealConfig, minDuration uint64) ([]cid.Cid, []deals.StorageDealConfig, error) {
 	stream, err := d.client.Store(ctx)
 	if err != nil {
@@ -93,7 +93,7 @@ func (d *Deals) Store(ctx context.Context, addr string, data io.Reader, dealConf
 	return cids, failedDeals, nil
 }
 
-// Watch returnas a channel with state changes of indicated proposals
+// Watch returns a channel with state changes of indicated proposals.
 func (d *Deals) Watch(ctx context.Context, proposals []cid.Cid) (<-chan WatchEvent, error) {
 	channel := make(chan WatchEvent)
 	proposalStrings := make([]string, len(proposals))
@@ -145,7 +145,7 @@ func (d *Deals) Watch(ctx context.Context, proposals []cid.Cid) (<-chan WatchEve
 	return channel, nil
 }
 
-// Retrieve is used to fetch data from filecoin
+// Retrieve is used to fetch data from filecoin.
 func (d *Deals) Retrieve(ctx context.Context, waddr string, cid cid.Cid) (io.Reader, error) {
 	req := &rpc.RetrieveRequest{
 		Address: waddr,

--- a/api/client/faults.go
+++ b/api/client/faults.go
@@ -12,7 +12,7 @@ type Faults struct {
 	client rpc.RPCServiceClient
 }
 
-// Get returns the current index of miner faults data
+// Get returns the current index of miner faults data.
 func (s *Faults) Get(ctx context.Context) (*faults.IndexSnapshot, error) {
 	reply, err := s.client.Get(ctx, &rpc.GetRequest{})
 	if err != nil {

--- a/api/client/ffs.go
+++ b/api/client/ffs.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -13,28 +14,28 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// FFS provides the API to create and interact with an FFS instance
+// FFS provides the API to create and interact with an FFS instance.
 type FFS struct {
 	client rpc.RPCServiceClient
 }
 
-// JobEvent represents an event for Watching a job
+// JobEvent represents an event for Watching a job.
 type JobEvent struct {
 	Job ffs.Job
 	Err error
 }
 
-// NewAddressOption is a function that changes a NewAddressConfig
+// NewAddressOption is a function that changes a NewAddressConfig.
 type NewAddressOption func(r *rpc.NewAddrRequest)
 
-// WithMakeDefault specifies if the new address should become the default
+// WithMakeDefault specifies if the new address should become the default.
 func WithMakeDefault(makeDefault bool) NewAddressOption {
 	return func(r *rpc.NewAddrRequest) {
 		r.MakeDefault = makeDefault
 	}
 }
 
-// WithAddressType specifies the type of address to create
+// WithAddressType specifies the type of address to create.
 func WithAddressType(addressType string) NewAddressOption {
 	return func(r *rpc.NewAddrRequest) {
 		r.AddressType = addressType
@@ -84,13 +85,13 @@ func WithHistory(enabled bool) WatchLogsOption {
 	}
 }
 
-// LogEvent represents an event for watching cid logs
+// LogEvent represents an event for watching cid logs.
 type LogEvent struct {
 	LogEntry ffs.LogEntry
 	Err      error
 }
 
-// Create creates a new FFS instance, returning the instance ID and auth token
+// Create creates a new FFS instance, returning the instance ID and auth token.
 func (f *FFS) Create(ctx context.Context) (string, string, error) {
 	r, err := f.client.Create(ctx, &rpc.CreateRequest{})
 	if err != nil {
@@ -112,7 +113,7 @@ func (f *FFS) ListAPI(ctx context.Context) ([]ffs.APIID, error) {
 	return res, nil
 }
 
-// ID returns the FFS instance ID
+// ID returns the FFS instance ID.
 func (f *FFS) ID(ctx context.Context) (ffs.APIID, error) {
 	resp, err := f.client.ID(ctx, &rpc.IDRequest{})
 	if err != nil {
@@ -121,7 +122,7 @@ func (f *FFS) ID(ctx context.Context) (ffs.APIID, error) {
 	return ffs.APIID(resp.Id), nil
 }
 
-// Addrs returns a list of addresses managed by the FFS instance
+// Addrs returns a list of addresses managed by the FFS instance.
 func (f *FFS) Addrs(ctx context.Context) ([]api.AddrInfo, error) {
 	resp, err := f.client.Addrs(ctx, &rpc.AddrsRequest{})
 	if err != nil {
@@ -138,7 +139,7 @@ func (f *FFS) Addrs(ctx context.Context) ([]api.AddrInfo, error) {
 	return addrs, nil
 }
 
-// DefaultConfig returns the default storage config
+// DefaultConfig returns the default storage config.
 func (f *FFS) DefaultConfig(ctx context.Context) (ffs.DefaultConfig, error) {
 	resp, err := f.client.DefaultConfig(ctx, &rpc.DefaultConfigRequest{})
 	if err != nil {
@@ -172,7 +173,7 @@ func (f *FFS) DefaultConfig(ctx context.Context) (ffs.DefaultConfig, error) {
 	}, nil
 }
 
-// NewAddr created a new wallet address managed by the FFS instance
+// NewAddr created a new wallet address managed by the FFS instance.
 func (f *FFS) NewAddr(ctx context.Context, name string, options ...NewAddressOption) (string, error) {
 	r := &rpc.NewAddrRequest{Name: name}
 	for _, opt := range options {
@@ -182,7 +183,7 @@ func (f *FFS) NewAddr(ctx context.Context, name string, options ...NewAddressOpt
 	return resp.Addr, err
 }
 
-// GetDefaultCidConfig returns a CidConfig built from the default storage config and prepped for the provided cid
+// GetDefaultCidConfig returns a CidConfig built from the default storage config and prepped for the provided cid.
 func (f *FFS) GetDefaultCidConfig(ctx context.Context, c cid.Cid) (ffs.CidConfig, error) {
 	res, err := f.client.GetDefaultCidConfig(ctx, &rpc.GetDefaultCidConfigRequest{Cid: c.String()})
 	if err != nil {
@@ -221,12 +222,12 @@ func (f *FFS) GetDefaultCidConfig(ctx context.Context, c cid.Cid) (ffs.CidConfig
 	}, nil
 }
 
-// GetCidConfig gets the current config for a cid
+// GetCidConfig gets the current config for a cid.
 func (f *FFS) GetCidConfig(ctx context.Context, c cid.Cid) (*rpc.GetCidConfigResponse, error) {
 	return f.client.GetCidConfig(ctx, &rpc.GetCidConfigRequest{Cid: c.String()})
 }
 
-// SetDefaultConfig sets the default storage config
+// SetDefaultConfig sets the default storage config.
 func (f *FFS) SetDefaultConfig(ctx context.Context, config ffs.DefaultConfig) error {
 	req := &rpc.SetDefaultConfigRequest{
 		Config: &rpc.DefaultConfig{
@@ -239,14 +240,14 @@ func (f *FFS) SetDefaultConfig(ctx context.Context, config ffs.DefaultConfig) er
 	return err
 }
 
-// Show returns information about the current storage state of a cid
+// Show returns information about the current storage state of a cid.
 func (f *FFS) Show(ctx context.Context, c cid.Cid) (*rpc.ShowResponse, error) {
 	return f.client.Show(ctx, &rpc.ShowRequest{
 		Cid: c.String(),
 	})
 }
 
-// Info returns information about the FFS instance
+// Info returns information about the FFS instance.
 func (f *FFS) Info(ctx context.Context) (api.InstanceInfo, error) {
 	res, err := f.client.Info(ctx, &rpc.InfoRequest{})
 	if err != nil {
@@ -385,7 +386,7 @@ func (f *FFS) Replace(ctx context.Context, c1 cid.Cid, c2 cid.Cid) (ffs.JobID, e
 	return ffs.JobID(resp.JobId), nil
 }
 
-// PushConfig push a new configuration for the Cid in the Hot and Cold layers
+// PushConfig push a new configuration for the Cid in the Hot and Cold layers.
 func (f *FFS) PushConfig(ctx context.Context, c cid.Cid, opts ...PushConfigOption) (ffs.JobID, error) {
 	req := &rpc.PushConfigRequest{Cid: c.String()}
 	for _, opt := range opts {
@@ -482,7 +483,7 @@ func (f *FFS) WatchLogs(ctx context.Context, ch chan<- LogEvent, c cid.Cid, opts
 	return nil
 }
 
-// SendFil sends fil from a managed address to any another address, returns immediately but funds are sent asynchronously
+// SendFil sends fil from a managed address to any another address, returns immediately but funds are sent asynchronously.
 func (f *FFS) SendFil(ctx context.Context, from string, to string, amount int64) error {
 	req := &rpc.SendFilRequest{
 		From:   from,
@@ -493,13 +494,13 @@ func (f *FFS) SendFil(ctx context.Context, from string, to string, amount int64)
 	return err
 }
 
-// Close terminates the running FFS instance
+// Close terminates the running FFS instance.
 func (f *FFS) Close(ctx context.Context) error {
 	_, err := f.client.Close(ctx, &rpc.CloseRequest{})
 	return err
 }
 
-// AddToHot allows you to add data to the Hot layer in preparation for pushing a cid config
+// AddToHot allows you to add data to the Hot layer in preparation for pushing a cid config.
 func (f *FFS) AddToHot(ctx context.Context, data io.Reader) (*cid.Cid, error) {
 	stream, err := f.client.AddToHot(ctx)
 	if err != nil {
@@ -589,7 +590,7 @@ func toRPCColdConfig(config ffs.ColdConfig) *rpc.ColdConfig {
 		Enabled: config.Enabled,
 		Filecoin: &rpc.FilConfig{
 			RepFactor:       int64(config.Filecoin.RepFactor),
-			DealMinDuration: int64(config.Filecoin.DealMinDuration),
+			DealMinDuration: config.Filecoin.DealMinDuration,
 			ExcludedMiners:  config.Filecoin.ExcludedMiners,
 			TrustedMiners:   config.Filecoin.TrustedMiners,
 			CountryCodes:    config.Filecoin.CountryCodes,
@@ -610,7 +611,7 @@ func fromRPCDealErrors(des []*rpc.DealError) ([]ffs.DealError, error) {
 			var err error
 			propCid, err = cid.Decode(de.ProposalCid)
 			if err != nil {
-				propCid = cid.Undef
+				return nil, fmt.Errorf("proposal cid is invalid")
 			}
 		}
 		res[i] = ffs.DealError{

--- a/api/client/ffs.go
+++ b/api/client/ffs.go
@@ -537,7 +537,7 @@ func (f *FFS) AddToHot(ctx context.Context, data io.Reader) (*cid.Cid, error) {
 	return &cid, nil
 }
 
-// ListPayChannels returns a list of payment channels
+// ListPayChannels returns a list of payment channels.
 func (f *FFS) ListPayChannels(ctx context.Context) ([]ffs.PaychInfo, error) {
 	resp, err := f.client.ListPayChannels(ctx, &rpc.ListPayChannelsRequest{})
 	if err != nil {
@@ -550,7 +550,7 @@ func (f *FFS) ListPayChannels(ctx context.Context) ([]ffs.PaychInfo, error) {
 	return infos, nil
 }
 
-// CreatePayChannel creates a new payment channel
+// CreatePayChannel creates a new payment channel.
 func (f *FFS) CreatePayChannel(ctx context.Context, from string, to string, amount uint64) (ffs.PaychInfo, cid.Cid, error) {
 	req := &rpc.CreatePayChannelRequest{
 		From:   from,
@@ -568,7 +568,7 @@ func (f *FFS) CreatePayChannel(ctx context.Context, from string, to string, amou
 	return fromRPCPaychInfo(resp.PayChannel), messageCid, nil
 }
 
-// RedeemPayChannel redeems a payment channel
+// RedeemPayChannel redeems a payment channel.
 func (f *FFS) RedeemPayChannel(ctx context.Context, addr string) error {
 	req := &rpc.RedeemPayChannelRequest{PayChannelAddr: addr}
 	_, err := f.client.RedeemPayChannel(ctx, req)

--- a/api/client/health.go
+++ b/api/client/health.go
@@ -7,12 +7,12 @@ import (
 	"github.com/textileio/powergate/health/rpc"
 )
 
-// Health provides an API for checking node Health
+// Health provides an API for checking node Health.
 type Health struct {
 	client rpc.RPCServiceClient
 }
 
-// Check returns the node health status and any related messages
+// Check returns the node health status and any related messages.
 func (health *Health) Check(ctx context.Context) (h.Status, []string, error) {
 	resp, err := health.client.Check(ctx, &rpc.CheckRequest{})
 	if err != nil {

--- a/api/client/miners.go
+++ b/api/client/miners.go
@@ -8,12 +8,12 @@ import (
 	"github.com/textileio/powergate/index/miner/rpc"
 )
 
-// Miners provides an API for viewing miner data
+// Miners provides an API for viewing miner data.
 type Miners struct {
 	client rpc.RPCServiceClient
 }
 
-// Get returns the current index of available asks
+// Get returns the current index of available asks.
 func (a *Miners) Get(ctx context.Context) (*miner.IndexSnapshot, error) {
 	reply, err := a.client.Get(ctx, &rpc.GetRequest{})
 	if err != nil {
@@ -45,8 +45,8 @@ func (a *Miners) Get(ctx context.Context) (*miner.IndexSnapshot, error) {
 		miners[key] = miner.OnChainData{
 			Power:         val.GetPower(),
 			RelativePower: float64(val.GetRelativePower()),
-			SectorSize:    uint64(val.GetSectorSize()),
-			ActiveDeals:   uint64(val.GetActiveDeals()),
+			SectorSize:    val.GetSectorSize(),
+			ActiveDeals:   val.GetActiveDeals(),
 		}
 	}
 

--- a/api/client/net.go
+++ b/api/client/net.go
@@ -10,12 +10,12 @@ import (
 	"github.com/textileio/powergate/net/rpc"
 )
 
-// Net provides the Net API
+// Net provides the Net API.
 type Net struct {
 	client rpc.RPCServiceClient
 }
 
-// ListenAddr returns listener address info for the local node
+// ListenAddr returns listener address info for the local node.
 func (net *Net) ListenAddr(ctx context.Context) (peer.AddrInfo, error) {
 	resp, err := net.client.ListenAddr(ctx, &rpc.ListenAddrRequest{})
 	if err != nil {
@@ -39,7 +39,7 @@ func (net *Net) ListenAddr(ctx context.Context) (peer.AddrInfo, error) {
 	}, nil
 }
 
-// Peers returns a list of peers
+// Peers returns a list of peers.
 func (net *Net) Peers(ctx context.Context) ([]n.PeerInfo, error) {
 	resp, err := net.client.Peers(ctx, &rpc.PeersRequest{})
 	if err != nil {
@@ -56,7 +56,7 @@ func (net *Net) Peers(ctx context.Context) ([]n.PeerInfo, error) {
 	return peerInfos, nil
 }
 
-// FindPeer finds a peer by peer id
+// FindPeer finds a peer by peer id.
 func (net *Net) FindPeer(ctx context.Context, peerID peer.ID) (n.PeerInfo, error) {
 	resp, err := net.client.FindPeer(ctx, &rpc.FindPeerRequest{PeerId: peerID.String()})
 	if err != nil {
@@ -65,7 +65,7 @@ func (net *Net) FindPeer(ctx context.Context, peerID peer.ID) (n.PeerInfo, error
 	return fromProtoPeerInfo(resp.PeerInfo)
 }
 
-// ConnectPeer connects to a peer
+// ConnectPeer connects to a peer.
 func (net *Net) ConnectPeer(ctx context.Context, addrInfo peer.AddrInfo) error {
 	addrs := make([]string, len(addrInfo.Addrs))
 	for i, addr := range addrInfo.Addrs {
@@ -79,13 +79,13 @@ func (net *Net) ConnectPeer(ctx context.Context, addrInfo peer.AddrInfo) error {
 	return err
 }
 
-// DisconnectPeer disconnects from a peer
+// DisconnectPeer disconnects from a peer.
 func (net *Net) DisconnectPeer(ctx context.Context, peerID peer.ID) error {
 	_, err := net.client.DisconnectPeer(ctx, &rpc.DisconnectPeerRequest{PeerId: peerID.String()})
 	return err
 }
 
-// Connectedness returns the connection status to a peer
+// Connectedness returns the connection status to a peer.
 func (net *Net) Connectedness(ctx context.Context, peerID peer.ID) (n.Connectedness, error) {
 	resp, err := net.client.Connectedness(ctx, &rpc.ConnectednessRequest{PeerId: peerID.String()})
 	if err != nil {

--- a/api/client/reputation.go
+++ b/api/client/reputation.go
@@ -8,12 +8,12 @@ import (
 	"github.com/textileio/powergate/reputation/rpc"
 )
 
-// Reputation provides an API for viewing reputation data
+// Reputation provides an API for viewing reputation data.
 type Reputation struct {
 	client rpc.RPCServiceClient
 }
 
-// AddSource adds a new external Source to be considered for reputation generation
+// AddSource adds a new external Source to be considered for reputation generation.
 func (r *Reputation) AddSource(ctx context.Context, id string, maddr ma.Multiaddr) error {
 	req := &rpc.AddSourceRequest{
 		Id:    id,
@@ -23,7 +23,7 @@ func (r *Reputation) AddSource(ctx context.Context, id string, maddr ma.Multiadd
 	return err
 }
 
-// GetTopMiners gets the top n miners with best score
+// GetTopMiners gets the top n miners with best score.
 func (r *Reputation) GetTopMiners(ctx context.Context, limit int) ([]reputation.MinerScore, error) {
 	req := &rpc.GetTopMinersRequest{Limit: int32(limit)}
 	reply, err := r.client.GetTopMiners(ctx, req)

--- a/api/client/utils_test.go
+++ b/api/client/utils_test.go
@@ -34,8 +34,8 @@ func setupServer(t *testing.T) func() {
 	ipfsAddrStr := "/ip4/127.0.0.1/tcp/" + dipfs.GetPort("5001/tcp")
 	ipfsAddr := util.MustParseAddr(ipfsAddrStr)
 
-	ddevnet := tests.LaunchDevnetDocker(t, 1, ipfsAddrStr)
-	devnetAddr := util.MustParseAddr("/ip4/127.0.0.1/tcp/" + ddevnet.GetPort("7777/tcp"))
+	devnet := tests.LaunchDevnetDocker(t, 1, ipfsAddrStr, false)
+	devnetAddr := util.MustParseAddr("/ip4/127.0.0.1/tcp/" + devnet.GetPort("7777/tcp"))
 
 	grpcMaddr := util.MustParseAddr(grpcHostAddress)
 	conf := server.Config{

--- a/api/client/wallet.go
+++ b/api/client/wallet.go
@@ -6,12 +6,12 @@ import (
 	"github.com/textileio/powergate/wallet/rpc"
 )
 
-// Wallet provides an API for managing filecoin wallets
+// Wallet provides an API for managing filecoin wallets.
 type Wallet struct {
 	client rpc.RPCServiceClient
 }
 
-// NewWallet creates a new filecoin address [bls|secp256k1]
+// NewWallet creates a new filecoin address [bls|secp256k1].
 func (w *Wallet) NewWallet(ctx context.Context, typ string) (string, error) {
 	resp, err := w.client.NewAddress(ctx, &rpc.NewAddressRequest{Type: typ})
 	if err != nil {
@@ -20,7 +20,7 @@ func (w *Wallet) NewWallet(ctx context.Context, typ string) (string, error) {
 	return resp.GetAddress(), nil
 }
 
-// WalletBalance gets a filecoin wallet's balance
+// WalletBalance gets a filecoin wallet's balance.
 func (w *Wallet) WalletBalance(ctx context.Context, address string) (uint64, error) {
 	resp, err := w.client.WalletBalance(ctx, &rpc.WalletBalanceRequest{Address: address})
 	if err != nil {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -63,7 +63,7 @@ var (
 	log = logging.Logger("server")
 )
 
-// Server represents the configured lotus client and filecoin grpc server
+// Server represents the configured lotus client and filecoin grpc server.
 type Server struct {
 	ds datastore.TxnDatastore
 
@@ -350,7 +350,7 @@ func startIndexHTTPServer(s *Server) *http.Server {
 	return srv
 }
 
-// Close shuts down the server
+// Close shuts down the server.
 func (s *Server) Close() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/api/stub/asks.go
+++ b/api/stub/asks.go
@@ -8,11 +8,11 @@ import (
 	"github.com/textileio/powergate/index/ask/runner"
 )
 
-// Asks stub
+// Asks stub.
 type Asks struct {
 }
 
-// Get returns the current index of available asks
+// Get returns the current index of available asks.
 func (a *Asks) Get(ctx context.Context) (*ask.Index, error) {
 	time.Sleep(time.Second * 3)
 	storage := map[string]ask.StorageAsk{
@@ -52,7 +52,7 @@ func (a *Asks) Get(ctx context.Context) (*ask.Index, error) {
 	}, nil
 }
 
-// Query executes a query to retrieve active Asks
+// Query executes a query to retrieve active Asks.
 func (a *Asks) Query(ctx context.Context, query runner.Query) ([]ask.StorageAsk, error) {
 	time.Sleep(time.Second * 3)
 	var asks = []ask.StorageAsk{

--- a/api/stub/client.go
+++ b/api/stub/client.go
@@ -4,7 +4,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Client provides the client api
+// Client provides the client api.
 type Client struct {
 	Asks       *Asks
 	Miners     *Miners
@@ -14,7 +14,7 @@ type Client struct {
 	Reputation *Reputation
 }
 
-// NewClient starts the client
+// NewClient starts the client.
 func NewClient(target string, opts ...grpc.DialOption) (*Client, error) {
 	client := &Client{
 		Asks:       &Asks{},
@@ -27,7 +27,7 @@ func NewClient(target string, opts ...grpc.DialOption) (*Client, error) {
 	return client, nil
 }
 
-// Close closes the client's grpc connection and cancels any active requests
+// Close closes the client's grpc connection and cancels any active requests.
 func (c *Client) Close() error {
 	return nil
 }

--- a/api/stub/deals.go
+++ b/api/stub/deals.go
@@ -11,7 +11,7 @@ import (
 	"github.com/textileio/powergate/deals"
 )
 
-// Deals provides an API for managing deals and storing data
+// Deals provides an API for managing deals and storing data.
 type Deals struct {
 }
 
@@ -39,7 +39,7 @@ func init() {
 }
 
 // Store creates a proposal deal for data using wallet addr to all miners indicated
-// by dealConfigs for duration epochs
+// by dealConfigs for duration epochs.
 func (d *Deals) Store(ctx context.Context, addr string, data io.Reader, dealConfigs []deals.StorageDealConfig, duration uint64) ([]cid.Cid, []deals.StorageDealConfig, error) {
 	time.Sleep(time.Second * 3)
 	success := []cid.Cid{}
@@ -54,7 +54,7 @@ func (d *Deals) Store(ctx context.Context, addr string, data io.Reader, dealConf
 	return success, failed, nil
 }
 
-// Watch returnas a channel with state changes of indicated proposals
+// Watch returnas a channel with state changes of indicated proposals.
 func (d *Deals) Watch(ctx context.Context, proposals []cid.Cid) (<-chan client.WatchEvent, error) {
 	ch := make(chan client.WatchEvent)
 	go driveChannel(ch, proposals)
@@ -76,7 +76,7 @@ func driveChannel(ch chan client.WatchEvent, proposals []cid.Cid) {
 	close(ch)
 }
 
-// Retrieve is used to fetch data from filecoin
+// Retrieve is used to fetch data from filecoin.
 func (d *Deals) Retrieve(ctx context.Context, waddr string, cid cid.Cid) (io.Reader, error) {
 	time.Sleep(time.Second * 3)
 	return strings.NewReader("hello there"), nil

--- a/api/stub/faults.go
+++ b/api/stub/faults.go
@@ -7,11 +7,11 @@ import (
 	"github.com/textileio/powergate/index/faults"
 )
 
-// Faults provides an API for viewing faults data
+// Faults provides an API for viewing faults data.
 type Faults struct {
 }
 
-// Get returns the current index of miner faults data
+// Get returns the current index of miner faults data.
 func (s *Faults) Get(ctx context.Context) (*faults.IndexSnapshot, error) {
 	time.Sleep(time.Second * 3)
 	miners := map[string]faults.Faults{

--- a/api/stub/miners.go
+++ b/api/stub/miners.go
@@ -7,11 +7,11 @@ import (
 	"github.com/textileio/powergate/index/miner"
 )
 
-// Miners provides an API for viewing miner data
+// Miners provides an API for viewing miner data.
 type Miners struct {
 }
 
-// Get returns the current index of available asks
+// Get returns the current index of available asks.
 func (a *Miners) Get(ctx context.Context) (*miner.IndexSnapshot, error) {
 	time.Sleep(time.Second * 3)
 	info := map[string]miner.Meta{

--- a/api/stub/reputation.go
+++ b/api/stub/reputation.go
@@ -8,17 +8,17 @@ import (
 	"github.com/textileio/powergate/reputation"
 )
 
-// Reputation provides an API for viewing reputation data
+// Reputation provides an API for viewing reputation data.
 type Reputation struct {
 }
 
-// AddSource adds a new external Source to be considered for reputation generation
+// AddSource adds a new external Source to be considered for reputation generation.
 func (r *Reputation) AddSource(ctx context.Context, id string, maddr ma.Multiaddr) error {
 	time.Sleep(time.Second * 3)
 	return nil
 }
 
-// GetTopMiners gets the top n miners with best score
+// GetTopMiners gets the top n miners with best score.
 func (r *Reputation) GetTopMiners(ctx context.Context, limit int) ([]reputation.MinerScore, error) {
 	time.Sleep(time.Second * 3)
 	topMiners := []reputation.MinerScore{

--- a/api/stub/wallet.go
+++ b/api/stub/wallet.go
@@ -5,17 +5,17 @@ import (
 	"time"
 )
 
-// Wallet provides an API for managing filecoin wallets
+// Wallet provides an API for managing filecoin wallets.
 type Wallet struct {
 }
 
-// NewWallet creates a new filecoin wallet [bls|secp256k1]
+// NewWallet creates a new filecoin wallet [bls|secp256k1].
 func (w *Wallet) NewWallet(ctx context.Context, typ string) (string, error) {
 	time.Sleep(time.Millisecond * 1000)
 	return "t16yt7dydsey3rzhefn4tudpn22pmp5ty2rmqyx7y", nil
 }
 
-// WalletBalance gets a filecoin wallet's balance
+// WalletBalance gets a filecoin wallet's balance.
 func (w *Wallet) WalletBalance(ctx context.Context, address string) (int64, error) {
 	time.Sleep(time.Millisecond * 1000)
 	return 47839, nil

--- a/chainstore/chainstore.go
+++ b/chainstore/chainstore.go
@@ -25,7 +25,7 @@ var (
 	dsNsID   = datastore.NewKey("/id")
 )
 
-// TipsetOrderer resolves ordering information between TipSets
+// TipsetOrderer resolves ordering information between TipSets.
 type TipsetOrderer interface {
 	Precedes(ctx context.Context, from, to types.TipSetKey) (bool, error)
 }
@@ -35,7 +35,7 @@ type checkpoint struct {
 	ts types.TipSetKey
 }
 
-// Store allows to save snapshoted state
+// Store allows to save snapshoted state.
 type Store struct {
 	fr TipsetOrderer
 
@@ -45,7 +45,7 @@ type Store struct {
 	lastID      uint64
 }
 
-// New returns a new Store
+// New returns a new Store.
 func New(ds datastore.TxnDatastore, fr TipsetOrderer) (*Store, error) {
 	s := &Store{
 		ds: ds,
@@ -211,7 +211,7 @@ func (s *Store) loadCheckpoints() error {
 	}
 	lst := make([]checkpoint, len(es))
 	for i, e := range es {
-		ts, err := types.TipSetKeyFromBytes([]byte(e.Value))
+		ts, err := types.TipSetKeyFromBytes(e.Value)
 		if err != nil {
 			return err
 		}

--- a/chainstore/chainstore_test.go
+++ b/chainstore/chainstore_test.go
@@ -169,7 +169,6 @@ func TestLoadSavedState(t *testing.T) {
 	if *bts != savedTipset || v.Tipset != savedTipset.String() || v.Nested.Pos != generateTotal-offset {
 		t.Fatalf("returned state is wrong")
 	}
-
 }
 
 type mockTipsetOrderer struct {

--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -15,12 +15,12 @@ const (
 	// hcCurrent = "current"
 )
 
-// ChainSync provides methods to resolve chain syncing situations
+// ChainSync provides methods to resolve chain syncing situations.
 type ChainSync struct {
 	api *apistruct.FullNodeStruct
 }
 
-// New returns a new ChainSync
+// New returns a new ChainSync.
 func New(api *apistruct.FullNodeStruct) *ChainSync {
 	return &ChainSync{
 		api: api,

--- a/cmd/pow/cmd/deal.go
+++ b/cmd/pow/cmd/deal.go
@@ -87,7 +87,7 @@ var dealCmd = &cobra.Command{
 
 		choices := make([]string, len(asks))
 		for i, ask := range asks {
-			expiry := time.Unix(int64(ask.Expiry), 0).Format("01/02/06 15:04 MST")
+			expiry := time.Unix(ask.Expiry, 0).Format("01/02/06 15:04 MST")
 			choices[i] = fmt.Sprintf("Price of %v with min piece size %v expiring %v", ask.Price, ask.MinPieceSize, expiry)
 		}
 

--- a/cmd/pow/cmd/miners_get.go
+++ b/cmd/pow/cmd/miners_get.go
@@ -72,7 +72,7 @@ var getMinersCmd = &cobra.Command{
 
 		RenderTable(os.Stdout, []string{"miner", "power", "relativePower", "sectorSize", "activeDeals"}, chainData)
 
-		lastUpdated := time.Unix(int64(index.OnChain.LastUpdated), 0).Format("01/02/06 15:04 MST")
+		lastUpdated := time.Unix(index.OnChain.LastUpdated, 0).Format("01/02/06 15:04 MST")
 
 		Message("Found on chain data for %d miners", aurora.White(len(index.OnChain.Miners)).Bold())
 		Message("Chain data last updated %v", aurora.White(lastUpdated).Bold())

--- a/cmd/pow/cmd/root.go
+++ b/cmd/pow/cmd/root.go
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-// Execute runs the root command
+// Execute runs the root command.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cmd/powbench/runner/runner.go
+++ b/cmd/powbench/runner/runner.go
@@ -85,7 +85,6 @@ func runSetup(ctx context.Context, c *client.Client, ts TestSetup) error {
 			if err := run(ctx, c, i, ts.RandSeed+i, ts.SampleSize, addr, ts.MinerAddr); err != nil {
 				chErr <- fmt.Errorf("failed run %d: %s", i, err)
 			}
-
 		}(i)
 	}
 	for i := 0; i < ts.MaxParallel; i++ {
@@ -166,7 +165,6 @@ func run(ctx context.Context, c *client.Client, id int, seed int, size int64, ad
 		if s.Job.Status == ffs.Success {
 			return nil
 		}
-
 	}
 	return fmt.Errorf("unexpected Job status watcher")
 }

--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -211,7 +211,7 @@ func setupLogging() error {
 
 func getRepoPath(devnet bool) (string, error) {
 	if devnet {
-		repoPath, err := ioutil.TempDir("/tmp/powergate", ".powergate-*")
+		repoPath, err := ioutil.TempDir("", ".powergate-*")
 		if err != nil {
 			return "", fmt.Errorf("generating temp for repo folder: %s", err)
 		}

--- a/deals/deals.go
+++ b/deals/deals.go
@@ -202,7 +202,7 @@ func (m *Module) GetDealStatus(ctx context.Context, pcid cid.Cid) (storagemarket
 	return di.State, md.State.SlashEpoch != -1, nil
 }
 
-// Watch returns a channel with state changes of indicated proposals
+// Watch returns a channel with state changes of indicated proposals.
 func (m *Module) Watch(ctx context.Context, proposals []cid.Cid) (<-chan DealInfo, error) {
 	if len(proposals) == 0 {
 		return nil, fmt.Errorf("proposals list can't be empty")
@@ -249,8 +249,7 @@ func notifyChanges(ctx context.Context, client *apistruct.FullNodeStruct, currSt
 			if dinfo.State == storagemarket.StorageDealActive {
 				ocd, err := client.StateMarketStorageDeal(ctx, dinfo.DealID, types.EmptyTSK)
 				if err != nil {
-					log.Errorf("getting on-chain deal info: %s", err)
-					continue
+					return fmt.Errorf("getting on-chain deal info: %s", err)
 				}
 				newState.ActivationEpoch = int64(ocd.State.SectorStartEpoch)
 				newState.StartEpoch = uint64(ocd.Proposal.StartEpoch)

--- a/deals/deals_test.go
+++ b/deals/deals_test.go
@@ -175,5 +175,4 @@ func randomBytesFromSource(size int, r *rand.Rand) []byte {
 	buf := make([]byte, size)
 	_, _ = r.Read(buf)
 	return buf
-
 }

--- a/deals/rpc/rpc.go
+++ b/deals/rpc/rpc.go
@@ -14,7 +14,7 @@ import (
 
 var log = logging.Logger("deals-rpc")
 
-// RPC implements the gprc service
+// RPC implements the gprc service.
 type RPC struct {
 	UnimplementedRPCServiceServer
 
@@ -28,7 +28,7 @@ type storeResult struct {
 	Err          error
 }
 
-// New creates a new rpc service
+// New creates a new rpc service.
 func New(dm *deals.Module) *RPC {
 	return &RPC{
 		Module: dm,
@@ -66,7 +66,7 @@ func store(ctx context.Context, dealsModule *deals.Module, storeParams *StorePar
 	ch <- storeResult{DataCid: dcid, ProposalCids: pcids, FailedDeals: failedDeals}
 }
 
-// Store calls deals.Store
+// Store calls deals.Store.
 func (s *RPC) Store(srv RPCService_StoreServer) error {
 	req, err := srv.Recv()
 	if err != nil {
@@ -123,7 +123,7 @@ func (s *RPC) Store(srv RPCService_StoreServer) error {
 	return srv.SendAndClose(&StoreResponse{DataCid: storeResult.DataCid.String(), ProposalCids: replyCids, FailedDeals: replyFailedDeals})
 }
 
-// Watch calls deals.Watch
+// Watch calls deals.Watch.
 func (s *RPC) Watch(req *WatchRequest, srv RPCService_WatchServer) error {
 	proposals := make([]cid.Cid, len(req.GetProposals()))
 	for i, proposal := range req.GetProposals() {
@@ -157,7 +157,7 @@ func (s *RPC) Watch(req *WatchRequest, srv RPCService_WatchServer) error {
 	return nil
 }
 
-// Retrieve calls deals.Retreive
+// Retrieve calls deals.Retreive.
 func (s *RPC) Retrieve(req *RetrieveRequest, srv RPCService_RetrieveServer) error {
 	cid, err := cid.Parse(req.GetCid())
 	if err != nil {

--- a/deals/types.go
+++ b/deals/types.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ipfs/go-cid"
 )
 
-// StorageDealConfig contains information about a storage proposal for a miner
+// StorageDealConfig contains information about a storage proposal for a miner.
 type StorageDealConfig struct {
 	Miner      string
 	EpochPrice uint64
@@ -20,7 +20,7 @@ type StoreResult struct {
 	Message     string
 }
 
-// DealInfo contains information about a proposal storage deal
+// DealInfo contains information about a proposal storage deal.
 type DealInfo struct {
 	ProposalCid cid.Cid
 	StateID     uint64

--- a/docker/docker-compose-devnet.yaml
+++ b/docker/docker-compose-devnet.yaml
@@ -1,10 +1,7 @@
 version: '3.7'
 
-volumes:
-   pow-devnet-shared:
-
 services:
-  
+
   powergate:
     build:
       context: ../
@@ -22,8 +19,6 @@ services:
       - POWD_DEVNET=true
       - POWD_LOTUSHOST=/dns4/lotus/tcp/7777
       - POWD_IPFSAPIADDR=/dns4/ipfs/tcp/5001
-    volumes:
-      - pow-devnet-shared:/tmp/powergate
     restart: unless-stopped
 
   ipfs:
@@ -39,5 +34,3 @@ services:
       - TEXLOTUSDEVNET_SPEED=1500
       - TEXLOTUSDEVNET_BIGSECTORS=true
       - TEXLOTUSDEVNET_IPFSADDR=/dns4/ipfs/tcp/5001
-    volumes:
-     - pow-devnet-shared:/tmp/powergate

--- a/fchost/fchost.go
+++ b/fchost/fchost.go
@@ -19,14 +19,14 @@ var (
 	log = logging.Logger("fchost")
 )
 
-// FilecoinHost is a libp2p host connected to the FC network
+// FilecoinHost is a libp2p host connected to the FC network.
 type FilecoinHost struct {
 	ping *ping.PingService
 	h    host.Host
 	dht  *dht.IpfsDHT
 }
 
-// New returns a new FilecoinHost
+// New returns a new FilecoinHost.
 func New(bootstrap bool) (*FilecoinHost, error) {
 	ctx := context.Background()
 	opts := getDefaultOpts()
@@ -54,7 +54,7 @@ func New(bootstrap bool) (*FilecoinHost, error) {
 	}, nil
 }
 
-// Bootstrap connects to the bootstrap peers
+// Bootstrap connects to the bootstrap peers.
 func (fc *FilecoinHost) Bootstrap() error {
 	log.Info("bootstraping libp2p host dht")
 	if err := fc.dht.Bootstrap(context.Background()); err != nil {

--- a/ffs/api/api.go
+++ b/ffs/api/api.go
@@ -113,7 +113,7 @@ func (i *API) ID() ffs.APIID {
 	return i.cfg.ID
 }
 
-// DefaultConfig returns the DefaultConfig
+// DefaultConfig returns the DefaultConfig.
 func (i *API) DefaultConfig() ffs.DefaultConfig {
 	return i.cfg.DefaultConfig
 }

--- a/ffs/api/api_actions.go
+++ b/ffs/api/api_actions.go
@@ -11,7 +11,7 @@ import (
 )
 
 // PushConfig push a new configuration for the Cid in the Hot and
-// Cold layer. If WithOverride opt isn't set it errors with ErrMustOverrideConfig
+// Cold layer. If WithOverride opt isn't set it errors with ErrMustOverrideConfig.
 func (i *API) PushConfig(c cid.Cid, opts ...PushConfigOption) (ffs.JobID, error) {
 	i.lock.Lock()
 	defer i.lock.Unlock()

--- a/ffs/api/api_paych.go
+++ b/ffs/api/api_paych.go
@@ -8,7 +8,7 @@ import (
 	"github.com/textileio/powergate/ffs"
 )
 
-// ListPayChannels lists all payment channels associated with this FFS
+// ListPayChannels lists all payment channels associated with this FFS.
 func (i *API) ListPayChannels(ctx context.Context) ([]ffs.PaychInfo, error) {
 	addrInfos := i.Addrs()
 	addrs := make([]string, len(addrInfos))
@@ -22,7 +22,7 @@ func (i *API) ListPayChannels(ctx context.Context) ([]ffs.PaychInfo, error) {
 	return res, nil
 }
 
-// CreatePayChannel creates a new payment channel
+// CreatePayChannel creates a new payment channel.
 func (i *API) CreatePayChannel(ctx context.Context, from string, to string, amount uint64) (ffs.PaychInfo, cid.Cid, error) {
 	if !i.isManagedAddress(from) {
 		return ffs.PaychInfo{}, cid.Undef, fmt.Errorf("%v is not managed by ffs instance", from)
@@ -30,7 +30,7 @@ func (i *API) CreatePayChannel(ctx context.Context, from string, to string, amou
 	return i.pm.Create(ctx, from, to, amount)
 }
 
-// RedeemPayChannel redeems a payment channel
+// RedeemPayChannel redeems a payment channel.
 func (i *API) RedeemPayChannel(ctx context.Context, addr string) error {
 	channels, err := i.ListPayChannels(ctx)
 	if err != nil {

--- a/ffs/api/api_wallet.go
+++ b/ffs/api/api_wallet.go
@@ -21,7 +21,7 @@ func (i *API) Addrs() []AddrInfo {
 	return addrs
 }
 
-// NewAddr creates a new address managed by the FFS instance
+// NewAddr creates a new address managed by the FFS instance.
 func (i *API) NewAddr(ctx context.Context, name string, options ...NewAddressOption) (string, error) {
 	i.lock.Lock()
 	defer i.lock.Unlock()
@@ -64,7 +64,7 @@ func (i *API) NewAddr(ctx context.Context, name string, options ...NewAddressOpt
 	return addr, nil
 }
 
-// SendFil sends fil from a managed address to any another address, returns immediately but funds are sent asynchronously
+// SendFil sends fil from a managed address to any another address, returns immediately but funds are sent asynchronously.
 func (i *API) SendFil(ctx context.Context, from string, to string, amount *big.Int) error {
 	if !i.isManagedAddress(from) {
 		return fmt.Errorf("%v is not managed by ffs instance", from)

--- a/ffs/api/option.go
+++ b/ffs/api/option.go
@@ -55,17 +55,17 @@ func (pc PushConfig) Validate() error {
 	return nil
 }
 
-// NewAddressOption is a function that changes a NewAddressConfig
+// NewAddressOption is a function that changes a NewAddressConfig.
 type NewAddressOption func(config *NewAddressConfig)
 
-// WithMakeDefault specifies if the new address should become the default
+// WithMakeDefault specifies if the new address should become the default.
 func WithMakeDefault(makeDefault bool) NewAddressOption {
 	return func(c *NewAddressConfig) {
 		c.makeDefault = makeDefault
 	}
 }
 
-// WithAddressType specifies the type of address to create
+// WithAddressType specifies the type of address to create.
 func WithAddressType(addressType string) NewAddressOption {
 	return func(c *NewAddressConfig) {
 		c.addressType = addressType

--- a/ffs/api/types.go
+++ b/ffs/api/types.go
@@ -19,7 +19,7 @@ type Config struct {
 	DefaultConfig ffs.DefaultConfig
 }
 
-// AddrInfo provides information about a wallet address
+// AddrInfo provides information about a wallet address.
 type AddrInfo struct {
 	Name string
 	Addr string
@@ -40,7 +40,7 @@ type BalanceInfo struct {
 	Balance uint64
 }
 
-// NewAddressConfig contains options for creating a new wallet address
+// NewAddressConfig contains options for creating a new wallet address.
 type NewAddressConfig struct {
 	makeDefault bool
 	addressType string

--- a/ffs/auth/auth.go
+++ b/ffs/auth/auth.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	// ErrNotFound indicates that the auth-token isn't registered
+	// ErrNotFound indicates that the auth-token isn't registered.
 	ErrNotFound = errors.New("auth token not found")
 
 	log = logging.Logger("ffs-auth")
@@ -32,14 +32,14 @@ type entry struct {
 	// This can be extended to have permissions
 }
 
-// New returns a new Auth
+// New returns a new Auth.
 func New(store ds.Datastore) *Auth {
 	return &Auth{
 		ds: store,
 	}
 }
 
-// Generate generates a new returned auth-token mapped to the iid
+// Generate generates a new returned auth-token mapped to the iid.
 func (r *Auth) Generate(iid ffs.APIID) (string, error) {
 	log.Infof("generating auth-token for instance %s", iid)
 	r.lock.Lock()

--- a/ffs/coreipfs/coreipfs.go
+++ b/ffs/coreipfs/coreipfs.go
@@ -33,7 +33,7 @@ type CoreIpfs struct {
 
 var _ ffs.HotStorage = (*CoreIpfs)(nil)
 
-// New returns a new CoreIpfs instance
+// New returns a new CoreIpfs instance.
 func New(ipfs iface.CoreAPI, l ffs.CidLogger) *CoreIpfs {
 	return &CoreIpfs{
 		ipfs: ipfs,

--- a/ffs/filcold/filcold.go
+++ b/ffs/filcold/filcold.go
@@ -65,7 +65,7 @@ func (fc *FilCold) Store(ctx context.Context, c cid.Cid, cfg ffs.FilConfig) ([]c
 		TrustedMiners:  cfg.TrustedMiners,
 		MaxPrice:       cfg.MaxPrice,
 	}
-	cfgs, err := makeDealConfigs(ctx, fc.ms, cfg.RepFactor, f)
+	cfgs, err := makeDealConfigs(fc.ms, cfg.RepFactor, f)
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("making deal configs: %s", err)
 	}
@@ -93,7 +93,6 @@ func (fc *FilCold) IsFilDealActive(ctx context.Context, proposalCid cid.Cid) (bo
 		return false, fmt.Errorf("getting deal state for %s: %s", proposalCid, err)
 	}
 	return !slashed && status == storagemarket.StorageDealActive, nil
-
 }
 
 // EnsureRenewals analyzes a FilInfo state for a Cid and executes renewals considering the FilConfig desired configuration.
@@ -152,7 +151,7 @@ func (fc *FilCold) renewDeal(ctx context.Context, c cid.Cid, size uint64, p ffs.
 		TrustedMiners: []string{p.Miner},
 		MaxPrice:      fcfg.MaxPrice,
 	}
-	dealConfig, err := makeDealConfigs(ctx, fc.ms, 1, f)
+	dealConfig, err := makeDealConfigs(fc.ms, 1, f)
 	if err != nil {
 		return ffs.FilStorage{}, nil, fmt.Errorf("making new deal config: %s", err)
 	}
@@ -272,7 +271,7 @@ func (fc *FilCold) getCidSize(ctx context.Context, c cid.Cid) (uint64, error) {
 	return uint64(s.CumulativeSize), nil
 }
 
-func makeDealConfigs(ctx context.Context, ms ffs.MinerSelector, cntMiners int, f ffs.MinerSelectorFilter) ([]deals.StorageDealConfig, error) {
+func makeDealConfigs(ms ffs.MinerSelector, cntMiners int, f ffs.MinerSelectorFilter) ([]deals.StorageDealConfig, error) {
 	mps, err := ms.GetMiners(cntMiners, f)
 	if err != nil {
 		return nil, fmt.Errorf("getting miners from minerselector: %s", err)

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -470,7 +470,7 @@ func TestFilecoinCountryFilter(t *testing.T) {
 	ipfs, ipfsAddr := createIPFS(t)
 	countries := []string{"China", "Uruguay"}
 	numMiners := len(countries)
-	client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, numMiners, ipfsAddr)
+	client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, numMiners, ipfsAddr, false)
 	addrs := make([]string, numMiners)
 	for i := 0; i < numMiners; i++ {
 		addrs[i] = fmt.Sprintf("t0%d", 1000+i)
@@ -507,7 +507,7 @@ func TestFilecoinCountryFilter(t *testing.T) {
 func TestFilecoinMaxPriceFilter(t *testing.T) {
 	t.Parallel()
 	ipfs, ipfsMAddr := createIPFS(t)
-	client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, 1, ipfsMAddr)
+	client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, 1, ipfsMAddr, false)
 	miner := fixed.Miner{Addr: "t01000", EpochPrice: 500000000}
 	ms := fixed.New([]fixed.Miner{miner})
 	ds := tests.NewTxMapDatastore()
@@ -1305,7 +1305,7 @@ func createIPFS(t *testing.T) (*httpapi.HttpApi, string) {
 }
 
 func newDevnet(t *testing.T, numMiners int, ipfsAddr string) (address.Address, *apistruct.FullNodeStruct, ffs.MinerSelector) {
-	client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, numMiners, ipfsAddr)
+	client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, numMiners, ipfsAddr, false)
 	addrs := make([]string, numMiners)
 	for i := 0; i < numMiners; i++ {
 		addrs[i] = fmt.Sprintf("t0%d", 1000+i)

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -595,7 +595,6 @@ func TestFilecoinEnableConfig(t *testing.T) {
 					requireIpfsPinnedCid(ctx, t, cid, ipfsAPI)
 				}
 			}
-
 		})
 	}
 }
@@ -689,7 +688,6 @@ func TestEnabledConfigChange(t *testing.T) {
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, &config)
 		requireFilStored(ctx, t, client, cid)
-
 	})
 	t.Run("ColdEnabledDisabled", func(t *testing.T) {
 		ctx := context.Background()

--- a/ffs/interfaces.go
+++ b/ffs/interfaces.go
@@ -15,17 +15,17 @@ type WalletManager interface {
 	NewAddress(context.Context, string) (string, error)
 	// Balance returns the current balance for an address.
 	Balance(context.Context, string) (uint64, error)
-	// SendFil sends fil from one address to another
+	// SendFil sends fil from one address to another.
 	SendFil(context.Context, string, string, *big.Int) error
 }
 
-// PaychManager provides access to payment channels
+// PaychManager provides access to payment channels.
 type PaychManager interface {
-	// List lists all payment channels involving the specified addresses
+	// List lists all payment channels involving the specified addresses.
 	List(ctx context.Context, addrs ...string) ([]PaychInfo, error)
-	// Create creates a new payment channel
+	// Create creates a new payment channel.
 	Create(ctx context.Context, from string, to string, amount uint64) (PaychInfo, cid.Cid, error)
-	// Redeem redeems a payment channel
+	// Redeem redeems a payment channel.
 	Redeem(ctx context.Context, ch string) error
 }
 

--- a/ffs/minerselector/fixed/fixed.go
+++ b/ffs/minerselector/fixed/fixed.go
@@ -48,7 +48,6 @@ func (fms *MinerSelector) GetMiners(n int, f ffs.MinerSelectorFilter) ([]ffs.Min
 				})
 				break
 			}
-
 		}
 		if len(res) == n {
 			return res, nil

--- a/ffs/rpc/rpc.go
+++ b/ffs/rpc/rpc.go
@@ -30,7 +30,7 @@ type RPC struct {
 	hot ffs.HotStorage
 }
 
-// New creates a new rpc service
+// New creates a new rpc service.
 func New(m *manager.Manager, hot ffs.HotStorage) *RPC {
 	return &RPC{
 		m:   m,
@@ -67,7 +67,7 @@ func (s *RPC) ListAPI(ctx context.Context, req *ListAPIRequest) (*ListAPIRespons
 	}, nil
 }
 
-// ID returns the API instance id
+// ID returns the API instance id.
 func (s *RPC) ID(ctx context.Context, req *IDRequest) (*IDResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -77,7 +77,7 @@ func (s *RPC) ID(ctx context.Context, req *IDRequest) (*IDResponse, error) {
 	return &IDResponse{Id: id.String()}, nil
 }
 
-// Addrs calls ffs.Addrs
+// Addrs calls ffs.Addrs.
 func (s *RPC) Addrs(ctx context.Context, req *AddrsRequest) (*AddrsResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -95,7 +95,7 @@ func (s *RPC) Addrs(ctx context.Context, req *AddrsRequest) (*AddrsResponse, err
 	return &AddrsResponse{Addrs: res}, nil
 }
 
-// DefaultConfig calls ffs.DefaultConfig
+// DefaultConfig calls ffs.DefaultConfig.
 func (s *RPC) DefaultConfig(ctx context.Context, req *DefaultConfigRequest) (*DefaultConfigResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -111,7 +111,7 @@ func (s *RPC) DefaultConfig(ctx context.Context, req *DefaultConfigRequest) (*De
 	}, nil
 }
 
-// NewAddr calls ffs.NewAddr
+// NewAddr calls ffs.NewAddr.
 func (s *RPC) NewAddr(ctx context.Context, req *NewAddrRequest) (*NewAddrResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -133,7 +133,7 @@ func (s *RPC) NewAddr(ctx context.Context, req *NewAddrRequest) (*NewAddrRespons
 	return &NewAddrResponse{Addr: addr}, nil
 }
 
-// GetDefaultCidConfig returns the default cid config prepped for the provided cid
+// GetDefaultCidConfig returns the default cid config prepped for the provided cid.
 func (s *RPC) GetDefaultCidConfig(ctx context.Context, req *GetDefaultCidConfigRequest) (*GetDefaultCidConfigResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -154,7 +154,7 @@ func (s *RPC) GetDefaultCidConfig(ctx context.Context, req *GetDefaultCidConfigR
 	}, nil
 }
 
-// GetCidConfig returns the cid config for the provided cid
+// GetCidConfig returns the cid config for the provided cid.
 func (s *RPC) GetCidConfig(ctx context.Context, req *GetCidConfigRequest) (*GetCidConfigResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -178,7 +178,7 @@ func (s *RPC) GetCidConfig(ctx context.Context, req *GetCidConfigRequest) (*GetC
 	}, nil
 }
 
-// SetDefaultConfig sets a new config to be used by default
+// SetDefaultConfig sets a new config to be used by default.
 func (s *RPC) SetDefaultConfig(ctx context.Context, req *SetDefaultConfigRequest) (*SetDefaultConfigResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -259,7 +259,7 @@ func (s *RPC) Info(ctx context.Context, req *InfoRequest) (*InfoResponse, error)
 	return reply, nil
 }
 
-// WatchJobs calls API.WatchJobs
+// WatchJobs calls API.WatchJobs.
 func (s *RPC) WatchJobs(req *WatchJobsRequest, srv RPCService_WatchJobsServer) error {
 	i, err := s.getInstanceByToken(srv.Context())
 	if err != nil {
@@ -354,7 +354,7 @@ func (s *RPC) WatchLogs(req *WatchLogsRequest, srv RPCService_WatchLogsServer) e
 	return nil
 }
 
-// Replace calls ffs.Replace
+// Replace calls ffs.Replace.
 func (s *RPC) Replace(ctx context.Context, req *ReplaceRequest) (*ReplaceResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -378,7 +378,7 @@ func (s *RPC) Replace(ctx context.Context, req *ReplaceRequest) (*ReplaceRespons
 	return &ReplaceResponse{JobId: jid.String()}, nil
 }
 
-// PushConfig applies the provided cid config
+// PushConfig applies the provided cid config.
 func (s *RPC) PushConfig(ctx context.Context, req *PushConfigRequest) (*PushConfigResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -420,7 +420,7 @@ func (s *RPC) PushConfig(ctx context.Context, req *PushConfigRequest) (*PushConf
 	}, nil
 }
 
-// Remove calls ffs.Remove
+// Remove calls ffs.Remove.
 func (s *RPC) Remove(ctx context.Context, req *RemoveRequest) (*RemoveResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -469,7 +469,7 @@ func (s *RPC) Get(req *GetRequest, srv RPCService_GetServer) error {
 	}
 }
 
-// SendFil sends fil from a managed address to any other address
+// SendFil sends fil from a managed address to any other address.
 func (s *RPC) SendFil(ctx context.Context, req *SendFilRequest) (*SendFilResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -481,7 +481,7 @@ func (s *RPC) SendFil(ctx context.Context, req *SendFilRequest) (*SendFilRespons
 	return &SendFilResponse{}, nil
 }
 
-// Close calls API.Close
+// Close calls API.Close.
 func (s *RPC) Close(ctx context.Context, req *CloseRequest) (*CloseResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -493,7 +493,7 @@ func (s *RPC) Close(ctx context.Context, req *CloseRequest) (*CloseResponse, err
 	return &CloseResponse{}, nil
 }
 
-// AddToHot stores data in the Hot Storage so the resulting cid can be used in PushConfig
+// AddToHot stores data in the Hot Storage so the resulting cid can be used in PushConfig.
 func (s *RPC) AddToHot(srv RPCService_AddToHotServer) error {
 	// check that an API instance exists so not just anyone can add data to the hot layer
 	if _, err := s.getInstanceByToken(srv.Context()); err != nil {
@@ -517,7 +517,7 @@ func (s *RPC) AddToHot(srv RPCService_AddToHotServer) error {
 	return srv.SendAndClose(&AddToHotResponse{Cid: c.String()})
 }
 
-// ListPayChannels lists all pay channels
+// ListPayChannels lists all pay channels.
 func (s *RPC) ListPayChannels(ctx context.Context, req *ListPayChannelsRequest) (*ListPayChannelsResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -534,7 +534,7 @@ func (s *RPC) ListPayChannels(ctx context.Context, req *ListPayChannelsRequest) 
 	return &ListPayChannelsResponse{PayChannels: respInfos}, nil
 }
 
-// CreatePayChannel creates a payment channel
+// CreatePayChannel creates a payment channel.
 func (s *RPC) CreatePayChannel(ctx context.Context, req *CreatePayChannelRequest) (*CreatePayChannelResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -551,7 +551,7 @@ func (s *RPC) CreatePayChannel(ctx context.Context, req *CreatePayChannelRequest
 	}, nil
 }
 
-// RedeemPayChannel redeems a payment channel
+// RedeemPayChannel redeems a payment channel.
 func (s *RPC) RedeemPayChannel(ctx context.Context, req *RedeemPayChannelRequest) (*RedeemPayChannelResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -563,7 +563,7 @@ func (s *RPC) RedeemPayChannel(ctx context.Context, req *RedeemPayChannelRequest
 	return &RedeemPayChannelResponse{}, nil
 }
 
-// ShowAll returns a list of CidInfo for all data stored in the FFS instance
+// ShowAll returns a list of CidInfo for all data stored in the FFS instance.
 func (s *RPC) ShowAll(ctx context.Context, req *ShowAllRequest) (*ShowAllResponse, error) {
 	i, err := s.getInstanceByToken(ctx)
 	if err != nil {
@@ -630,7 +630,7 @@ func toRPCColdConfig(config ffs.ColdConfig) *ColdConfig {
 		Enabled: config.Enabled,
 		Filecoin: &FilConfig{
 			RepFactor:       int64(config.Filecoin.RepFactor),
-			DealMinDuration: int64(config.Filecoin.DealMinDuration),
+			DealMinDuration: config.Filecoin.DealMinDuration,
 			ExcludedMiners:  config.Filecoin.ExcludedMiners,
 			TrustedMiners:   config.Filecoin.TrustedMiners,
 			CountryCodes:    config.Filecoin.CountryCodes,

--- a/ffs/scheduler/internal/astore/astore.go
+++ b/ffs/scheduler/internal/astore/astore.go
@@ -95,7 +95,6 @@ func (s *Store) Remove(c cid.Cid) error {
 		}
 	}
 	return ErrNotFound
-
 }
 
 // GetRenewable returns all Actions that have CidConfigs that have the Renew flag enabled
@@ -144,7 +143,6 @@ func (s *Store) query(selector func(Action) bool) ([]Action, error) {
 		}
 	}
 	return as, nil
-
 }
 
 func makeKey(jid ffs.JobID) datastore.Key {

--- a/ffs/scheduler/internal/cistore/cistore.go
+++ b/ffs/scheduler/internal/cistore/cistore.go
@@ -17,7 +17,7 @@ var (
 	ErrNotFound = errors.New("cid info not found")
 )
 
-// Store is an Datastore implementation of CidInfoStore
+// Store is an Datastore implementation of CidInfoStore.
 type Store struct {
 	ds datastore.Datastore
 }
@@ -29,7 +29,7 @@ func New(ds datastore.Datastore) *Store {
 	}
 }
 
-// Get  gets the current stored state of a Cid
+// Get  gets the current stored state of a Cid.
 func (s *Store) Get(c cid.Cid) (ffs.CidInfo, error) {
 	var ci ffs.CidInfo
 	buf, err := s.ds.Get(makeKey(c))
@@ -45,7 +45,7 @@ func (s *Store) Get(c cid.Cid) (ffs.CidInfo, error) {
 	return ci, nil
 }
 
-// Put saves a new storing state for a Cid
+// Put saves a new storing state for a Cid.
 func (s *Store) Put(ci ffs.CidInfo) error {
 	if !ci.Cid.Defined() {
 		return fmt.Errorf("cid can't be undefined")

--- a/ffs/scheduler/internal/jstore/jstore.go
+++ b/ffs/scheduler/internal/jstore/jstore.go
@@ -134,7 +134,6 @@ func (s *Store) GetExecutingJobs() []ffs.JobID {
 		i++
 	}
 	return res
-
 }
 
 func (s *Store) cancelQueued(c cid.Cid) error {

--- a/ffs/scheduler/internal/jstore/jstore_test.go
+++ b/ffs/scheduler/internal/jstore/jstore_test.go
@@ -128,7 +128,6 @@ func TestStartedDeals(t *testing.T) {
 	fds, err = s.GetStartedDeals(cidData)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(fds))
-
 }
 
 func createJob() ffs.Job {
@@ -145,7 +144,7 @@ func createJob() ffs.Job {
 
 func create(t *testing.T) *Store {
 	ds := tests.NewTxMapDatastore()
-	store, _ := New(ds)
+	store, err := New(ds)
+	require.NoError(t, err)
 	return store
-
 }

--- a/ffs/types.go
+++ b/ffs/types.go
@@ -419,15 +419,15 @@ type LogEntry struct {
 	Msg       string
 }
 
-// PaychDir specifies the direction of a payment channel
+// PaychDir specifies the direction of a payment channel.
 type PaychDir int
 
 const (
-	// PaychDirUnspecified is an undefined direction
+	// PaychDirUnspecified is an undefined direction.
 	PaychDirUnspecified PaychDir = iota
-	// PaychDirInbound is an inbound direction
+	// PaychDirInbound is an inbound direction.
 	PaychDirInbound
-	// PaychDirOutbound is an outbound direction
+	// PaychDirOutbound is an outbound direction.
 	PaychDirOutbound
 )
 
@@ -438,7 +438,7 @@ var PaychDirStr = map[PaychDir]string{
 	PaychDirOutbound:    "Outbound",
 }
 
-// PaychInfo holds information about a payment channel
+// PaychInfo holds information about a payment channel.
 type PaychInfo struct {
 	CtlAddr   string
 	Addr      string

--- a/ffs/types.go
+++ b/ffs/types.go
@@ -183,13 +183,13 @@ func (c CidConfig) WithColdFilRenew(enabled bool, threshold int) CidConfig {
 }
 
 // WithColdMaxPrice specifies the max price that should be considered for
-// deal asks even when all other filers match
+// deal asks even when all other filers match.
 func (c CidConfig) WithColdMaxPrice(maxPrice uint64) CidConfig {
 	c.Cold.Filecoin.MaxPrice = maxPrice
 	return c
 }
 
-// WithColdAddr specifies the wallet address that should be used for transactions
+// WithColdAddr specifies the wallet address that should be used for transactions.
 func (c CidConfig) WithColdAddr(addr string) CidConfig {
 	c.Cold.Filecoin.Addr = addr
 	return c

--- a/filchain/filchain.go
+++ b/filchain/filchain.go
@@ -12,12 +12,12 @@ type FilChain struct {
 	api API
 }
 
-// API interacts with a Lotus full-node
+// API interacts with a Lotus full-node.
 type API interface {
 	ChainHead(ctx context.Context) (*types.TipSet, error)
 }
 
-// New creates a new deal module
+// New creates a new deal module.
 func New(api API) *FilChain {
 	return &FilChain{
 		api: api,

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -284,7 +284,7 @@ func (g *Gateway) reputationHandler(c *gin.Context) {
 }
 
 func uint64ToTime(value int64) time.Time {
-	return time.Unix(int64(value), 0)
+	return time.Unix(value, 0)
 }
 
 func timeToString(t time.Time) string {

--- a/health/module.go
+++ b/health/module.go
@@ -12,17 +12,17 @@ type Module struct {
 	net net.Module
 }
 
-// Status represents the node's health status
+// Status represents the node's health status.
 type Status int
 
 const (
-	// Unspecified is an unknown or empty status
+	// Unspecified is an unknown or empty status.
 	Unspecified Status = iota
 	// Ok specifies the node is healthy
 	Ok
-	// Degraded specifies there are problems with the node health
+	// Degraded specifies there are problems with the node health.
 	Degraded
-	// Error specifies there was an error when determining node health
+	// Error specifies there was an error when determining node health.
 	Error
 )
 
@@ -38,7 +38,7 @@ func (s Status) String() string {
 	return names[s]
 }
 
-// New creates a new net module
+// New creates a new net module.
 func New(net net.Module) *Module {
 	m := &Module{
 		net: net,
@@ -46,7 +46,7 @@ func New(net net.Module) *Module {
 	return m
 }
 
-// Check reutuns the current health status and any messages related to the status
+// Check returns the current health status and any messages related to the status.
 func (m *Module) Check(ctx context.Context) (status Status, messages []string, err error) {
 	peers, err := m.net.Peers(ctx)
 	if err != nil {

--- a/health/rpc/rpc.go
+++ b/health/rpc/rpc.go
@@ -6,19 +6,19 @@ import (
 	"github.com/textileio/powergate/health"
 )
 
-// RPC implements the rpc service
+// RPC implements the rpc service.
 type RPC struct {
 	UnimplementedRPCServiceServer
 
 	module *health.Module
 }
 
-// New creates a new rpc service
+// New creates a new rpc service.
 func New(m *health.Module) *RPC {
 	return &RPC{module: m}
 }
 
-// Check calls module.Check
+// Check calls module.Check.
 func (a *RPC) Check(ctx context.Context, req *CheckRequest) (*CheckResponse, error) {
 	status, messages, err := a.module.Check(ctx)
 	if err != nil {

--- a/index/ask/rpc/rpc.go
+++ b/index/ask/rpc/rpc.go
@@ -6,14 +6,14 @@ import (
 	"github.com/textileio/powergate/index/ask/runner"
 )
 
-// RPC implements the gprc service
+// RPC implements the gprc service.
 type RPC struct {
 	UnimplementedRPCServiceServer
 
 	index *runner.Runner
 }
 
-// New creates a new rpc service
+// New creates a new rpc service.
 func New(ai *runner.Runner) *RPC {
 	return &RPC{
 		index: ai,

--- a/index/ask/runner/runner.go
+++ b/index/ask/runner/runner.go
@@ -29,7 +29,7 @@ var (
 	log = logging.Logger("index-ask")
 )
 
-// Runner contains cached information about markets
+// Runner contains cached information about markets.
 type Runner struct {
 	api      *apistruct.FullNodeStruct
 	store    *store.Store
@@ -46,7 +46,7 @@ type Runner struct {
 	closed   bool
 }
 
-// Query specifies filtering and paging data to retrieve active Asks
+// Query specifies filtering and paging data to retrieve active Asks.
 type Query struct {
 	MaxPrice  uint64
 	PieceSize uint64
@@ -81,7 +81,7 @@ func New(ds datastore.TxnDatastore, api *apistruct.FullNodeStruct) (*Runner, err
 	return ai, nil
 }
 
-// Get returns a copy of the current index data
+// Get returns a copy of the current index data.
 func (ai *Runner) Get() ask.Index {
 	ai.lock.Lock()
 	defer ai.lock.Unlock()
@@ -96,7 +96,7 @@ func (ai *Runner) Get() ask.Index {
 	return index
 }
 
-// Query executes a query to retrieve active Asks
+// Query executes a query to retrieve active Asks.
 func (ai *Runner) Query(q Query) ([]ask.StorageAsk, error) {
 	ai.lock.Lock()
 	defer ai.lock.Unlock()
@@ -127,12 +127,12 @@ func (ai *Runner) Listen() <-chan struct{} {
 	return ai.signaler.Listen()
 }
 
-// Unregister unregisters a channel signaler from the signaler hub
+// Unregister unregisters a channel signaler from the signaler hub.
 func (ai *Runner) Unregister(c chan struct{}) {
 	ai.signaler.Unregister(c)
 }
 
-// Close closes the AskIndex
+// Close closes the AskIndex.
 func (ai *Runner) Close() error {
 	log.Info("Closing")
 	ai.clsLock.Lock()
@@ -147,7 +147,7 @@ func (ai *Runner) Close() error {
 	return nil
 }
 
-// start is a long running job that updates asks information in the market
+// start is a long running job that updates asks information in the market.
 func (ai *Runner) start() {
 	defer close(ai.finished)
 	if err := ai.update(); err != nil {
@@ -188,7 +188,7 @@ func (ai *Runner) update() error {
 	return nil
 }
 
-// generateIndex returns a fresh index
+// generateIndex returns a fresh index.
 func generateIndex(ctx context.Context, api *apistruct.FullNodeStruct) (ask.Index, []*ask.StorageAsk, error) {
 	addrs, err := api.StateListMiners(ctx, types.EmptyTSK)
 	if err != nil {

--- a/index/ask/runner/runner_test.go
+++ b/index/ask/runner/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	logging "github.com/ipfs/go-log/v2"
+	"github.com/stretchr/testify/require"
 	"github.com/textileio/powergate/index/ask"
 	"github.com/textileio/powergate/tests"
 )
@@ -25,7 +26,7 @@ func TestFreshBuild(t *testing.T) {
 	dnet, _, miners := tests.CreateLocalDevnet(t, 1)
 
 	index, _, err := generateIndex(ctx, dnet)
-	checkErr(t, err)
+	require.NoError(t, err)
 
 	// We should have storage info about every miner in devnet
 	for _, m := range miners {
@@ -84,12 +85,5 @@ func TestQueryAsk(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tt.expect, got)
 			}
 		})
-	}
-}
-
-func checkErr(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Fatal(err)
 	}
 }

--- a/index/ask/types.go
+++ b/index/ask/types.go
@@ -4,14 +4,14 @@ import (
 	"time"
 )
 
-// Index contains Ask information from markets
+// Index contains Ask information from markets.
 type Index struct {
 	LastUpdated        time.Time
 	StorageMedianPrice uint64
 	Storage            map[string]StorageAsk
 }
 
-// StorageAsk has information about an active ask from a storage miner
+// StorageAsk has information about an active ask from a storage miner.
 type StorageAsk struct {
 	Miner        string
 	Price        uint64

--- a/index/faults/faults.go
+++ b/index/faults/faults.go
@@ -26,13 +26,13 @@ const (
 var (
 	// hOffset is the # of tipsets from the heaviest chain to
 	// consider for index updating; this to reduce sensibility to
-	// chain reorgs
+	// chain reorgs.
 	hOffset = abi.ChainEpoch(20)
 
 	log = logging.Logger("index-faults")
 )
 
-// Index builds and provides faults history of miners
+// Index builds and provides faults history of miners.
 type Index struct {
 	api      *apistruct.FullNodeStruct
 	store    *chainstore.Store
@@ -75,7 +75,7 @@ func New(ds datastore.TxnDatastore, api *apistruct.FullNodeStruct) (*Index, erro
 	return s, nil
 }
 
-// Get returns a copy of the current index information
+// Get returns a copy of the current index information.
 func (s *Index) Get() IndexSnapshot {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -197,7 +197,6 @@ func (s *Index) updateIndex() error {
 			currFaults := index.Miners[f.Miner.String()]
 			currFaults.Epochs = append(currFaults.Epochs, int64(f.Epoch))
 			index.Miners[f.Miner.String()] = currFaults
-
 		}
 
 		// Persist partial progress in each finished section-path.
@@ -224,7 +223,7 @@ func (s *Index) updateIndex() error {
 		stats.Record(mctx, mRefreshProgress.M(float64(i)/float64(len(path))))
 	}
 
-	stats.Record(mctx, mRefreshDuration.M(int64(time.Since(start).Milliseconds())))
+	stats.Record(mctx, mRefreshDuration.M(time.Since(start).Milliseconds()))
 	stats.Record(mctx, mUpdatedHeight.M(int64(targetTs.Height())))
 	stats.Record(mctx, mRefreshProgress.M(1))
 	log.Info("faults index updated")

--- a/index/faults/rpc/rpc.go
+++ b/index/faults/rpc/rpc.go
@@ -6,21 +6,21 @@ import (
 	"github.com/textileio/powergate/index/faults"
 )
 
-// RPC implements the gprc service
+// RPC implements the gprc service.
 type RPC struct {
 	UnimplementedRPCServiceServer
 
 	index *faults.Index
 }
 
-// New creates a new rpc service
+// New creates a new rpc service.
 func New(fi *faults.Index) *RPC {
 	return &RPC{
 		index: fi,
 	}
 }
 
-// Get calls faults index Get
+// Get calls faults index Get.
 func (s *RPC) Get(ctx context.Context, req *GetRequest) (*GetResponse, error) {
 	index := s.index.Get()
 

--- a/index/miner/meta.go
+++ b/index/miner/meta.go
@@ -26,7 +26,7 @@ var (
 	dsKeyMetaIndex = dsBase.ChildString("meta")
 )
 
-// metaWorker makes a pass on refreshing metadata information about known miners
+// metaWorker makes a pass on refreshing metadata information about known miners.
 func (mi *Index) metaWorker() {
 	defer func() { mi.finished <- struct{}{} }()
 	mi.chMeta <- struct{}{}
@@ -51,11 +51,7 @@ func (mi *Index) metaWorker() {
 				}
 			}
 			mi.lock.Unlock()
-			newIndex, err := updateMetaIndex(mi.ctx, mi.api, mi.h, mi.lr, addrs)
-			if err != nil {
-				log.Errorf("error when updating meta index: %s", err)
-				break
-			}
+			newIndex := updateMetaIndex(mi.ctx, mi.api, mi.h, mi.lr, addrs)
 			if err := mi.persistMetaIndex(newIndex); err != nil {
 				log.Errorf("error when persisting meta index: %s", err)
 			}
@@ -70,7 +66,7 @@ func (mi *Index) metaWorker() {
 
 // updateMetaIndex generates a new index that contains fresh metadata information
 // of addrs miners.
-func updateMetaIndex(ctx context.Context, api *apistruct.FullNodeStruct, h P2PHost, lr iplocation.LocationResolver, addrs []string) (MetaIndex, error) {
+func updateMetaIndex(ctx context.Context, api *apistruct.FullNodeStruct, h P2PHost, lr iplocation.LocationResolver, addrs []string) MetaIndex {
 	index := MetaIndex{
 		Info: make(map[string]Meta),
 	}
@@ -109,7 +105,7 @@ func updateMetaIndex(ctx context.Context, api *apistruct.FullNodeStruct, h P2PHo
 	ctx, _ = tag.New(context.Background(), tag.Insert(metricOnline, "offline"))
 	stats.Record(ctx, mMetaPingCount.M(int64(index.Offline)))
 
-	return index, nil
+	return index
 }
 
 func merge(old Meta, upt Meta) Meta {
@@ -128,7 +124,7 @@ func merge(old Meta, upt Meta) Meta {
 	return upt
 }
 
-// getMeta returns fresh metadata information about a miner
+// getMeta returns fresh metadata information about a miner.
 func getMeta(ctx context.Context, c *apistruct.FullNodeStruct, h P2PHost, lr iplocation.LocationResolver, straddr string) (Meta, error) {
 	si := Meta{
 		LastUpdated: time.Now(),
@@ -166,7 +162,7 @@ func getMeta(ctx context.Context, c *apistruct.FullNodeStruct, h P2PHost, lr ipl
 	return si, nil
 }
 
-// persisteMetaIndex saves to datastore a new MetaIndex
+// persisteMetaIndex saves to datastore a new MetaIndex.
 func (mi *Index) persistMetaIndex(index MetaIndex) error {
 	buf, err := json.Marshal(index)
 	if err != nil {

--- a/index/miner/miner.go
+++ b/index/miner/miner.go
@@ -37,7 +37,7 @@ type P2PHost interface {
 	GetAgentVersion(pid peer.ID) string
 }
 
-// Index builds and provides information about FC miners
+// Index builds and provides information about FC miners.
 type Index struct {
 	api      *apistruct.FullNodeStruct
 	ds       datastore.TxnDatastore
@@ -92,7 +92,7 @@ func New(ds datastore.TxnDatastore, api *apistruct.FullNodeStruct, h P2PHost, lr
 	return mi, nil
 }
 
-// Get returns a copy of the current index information
+// Get returns a copy of the current index information.
 func (mi *Index) Get() IndexSnapshot {
 	mi.lock.Lock()
 	defer mi.lock.Unlock()
@@ -122,12 +122,12 @@ func (mi *Index) Listen() <-chan struct{} {
 	return mi.signaler.Listen()
 }
 
-// Unregister unregisters a channel signaler from the signaler hub
+// Unregister unregisters a channel signaler from the signaler hub.
 func (mi *Index) Unregister(c chan struct{}) {
 	mi.signaler.Unregister(c)
 }
 
-// Close closes a MinerIndex
+// Close closes a MinerIndex.
 func (mi *Index) Close() error {
 	log.Info("Closing")
 	mi.clsLock.Lock()

--- a/index/miner/onchain.go
+++ b/index/miner/onchain.go
@@ -20,12 +20,12 @@ const (
 	fullThreshold = 100
 	// hOffset is the # of tipsets from the heaviest chain to
 	// consider for index updating; this to reduce sensibility to
-	// chain reorgs
+	// chain reorgs.
 	hOffset = 5
 )
 
 // updateOnChainIndex updates on-chain index information in the direction of heaviest tipset
-// with some height offset to reduce sensibility to reorgs
+// with some height offset to reduce sensibility to reorgs.
 func (mi *Index) updateOnChainIndex() error {
 	log.Info("updating on-chain index...")
 	heaviest, err := mi.api.ChainHead(mi.ctx)
@@ -62,7 +62,6 @@ func (mi *Index) updateOnChainIndex() error {
 		if err := fullRefresh(mi.ctx, mi.api, &chainIndex); err != nil {
 			return fmt.Errorf("error doing full refresh: %s", err)
 		}
-
 	} else {
 		mctx, _ = tag.New(mctx, tag.Insert(metricRefreshType, "delta"))
 		if err := deltaRefresh(mi.ctx, mi.api, &chainIndex, *ts, new); err != nil {
@@ -70,7 +69,7 @@ func (mi *Index) updateOnChainIndex() error {
 		}
 	}
 	chainIndex.LastUpdated = int64(new.Height())
-	stats.Record(mctx, mRefreshDuration.M(int64(time.Since(start).Milliseconds())))
+	stats.Record(mctx, mRefreshDuration.M(time.Since(start).Milliseconds()))
 
 	mi.lock.Lock()
 	mi.index.OnChain = chainIndex
@@ -80,7 +79,7 @@ func (mi *Index) updateOnChainIndex() error {
 		return fmt.Errorf("error when saving state to store: %s", err)
 	}
 	mi.signaler.Signal()
-	stats.Record(context.Background(), mUpdatedHeight.M(int64(chainIndex.LastUpdated)))
+	stats.Record(context.Background(), mUpdatedHeight.M(chainIndex.LastUpdated))
 
 	return nil
 }

--- a/index/miner/rpc/rpc.go
+++ b/index/miner/rpc/rpc.go
@@ -6,21 +6,21 @@ import (
 	"github.com/textileio/powergate/index/miner"
 )
 
-// RPC implements the gprc service
+// RPC implements the gprc service.
 type RPC struct {
 	UnimplementedRPCServiceServer
 
 	index *miner.Index
 }
 
-// New creates a new rpc service
+// New creates a new rpc service.
 func New(mi *miner.Index) *RPC {
 	return &RPC{
 		index: mi,
 	}
 }
 
-// Get calls miner index Get
+// Get calls miner index Get.
 func (s *RPC) Get(ctx context.Context, req *GetRequest) (*GetResponse, error) {
 	index := s.index.Get()
 

--- a/index/miner/types.go
+++ b/index/miner/types.go
@@ -4,13 +4,13 @@ import (
 	"time"
 )
 
-// IndexSnapshot contains on-chain and off-chain information about miners
+// IndexSnapshot contains on-chain and off-chain information about miners.
 type IndexSnapshot struct {
 	Meta    MetaIndex
 	OnChain ChainIndex
 }
 
-// ChainIndex contains on-chain information about miners
+// ChainIndex contains on-chain information about miners.
 type ChainIndex struct {
 	LastUpdated int64
 	Miners      map[string]OnChainData
@@ -24,14 +24,14 @@ type OnChainData struct {
 	ActiveDeals   uint64
 }
 
-// MetaIndex contains off-chain information about miners
+// MetaIndex contains off-chain information about miners.
 type MetaIndex struct {
 	Online  uint32
 	Offline uint32
 	Info    map[string]Meta
 }
 
-// Meta contains off-chain information of a miner
+// Meta contains off-chain information of a miner.
 type Meta struct {
 	LastUpdated time.Time
 	UserAgent   string
@@ -39,7 +39,7 @@ type Meta struct {
 	Online      bool
 }
 
-// Location contains geeoinformation
+// Location contains geeoinformation.
 type Location struct {
 	Country   string
 	Longitude float32

--- a/iplocation/ip2location/ip2location.go
+++ b/iplocation/ip2location/ip2location.go
@@ -27,11 +27,11 @@ var (
 var _ iplocation.LocationResolver = (*IP2Location)(nil)
 
 // IP2Location is a LocationResolver implementation to get geoinformation of
-// multiaddrs of a host
+// multiaddrs of a host.
 type IP2Location struct {
 }
 
-// New returns a new IP2Location
+// New returns a new IP2Location.
 func New(paths []string) *IP2Location {
 	lock.Lock()
 	defer lock.Unlock()
@@ -46,7 +46,7 @@ func New(paths []string) *IP2Location {
 	return instance
 }
 
-// Resolve returns geoinformation about a set of multiaddresses of a single host
+// Resolve returns geoinformation about a set of multiaddresses of a single host.
 func (il *IP2Location) Resolve(mas []multiaddr.Multiaddr) (iplocation.Location, error) {
 	for _, ma := range mas {
 		ipport, err := util.TCPAddrFromMultiAddr(ma)
@@ -72,7 +72,7 @@ func (il *IP2Location) Resolve(mas []multiaddr.Multiaddr) (iplocation.Location, 
 	return iplocation.Location{}, iplocation.ErrCantResolve
 }
 
-// Close closes IPLocation resolver
+// Close closes IPLocation resolver.
 func (il *IP2Location) Close() {
 	lock.Lock()
 	defer lock.Unlock()

--- a/iplocation/iplocation.go
+++ b/iplocation/iplocation.go
@@ -7,11 +7,11 @@ import (
 )
 
 var (
-	//ErrCantResolve indicates that geoinformation couldn't be resolved for a host
+	// ErrCantResolve indicates that geoinformation couldn't be resolved for a host.
 	ErrCantResolve = errors.New("can't resolve multiaddr location information")
 )
 
-// Location contains geoinformation
+// Location contains geoinformation.
 type Location struct {
 	Country   string
 	Latitude  float32
@@ -19,7 +19,7 @@ type Location struct {
 }
 
 // LocationResolver resolver gets location information from a set of multiaddresses of
-// a single host
+// a single host.
 type LocationResolver interface {
 	Resolve(mas []multiaddr.Multiaddr) (Location, error)
 }

--- a/lotus/client.go
+++ b/lotus/client.go
@@ -21,7 +21,7 @@ var (
 	log                     = logging.Logger("deals")
 )
 
-// New creates a new client to Lotus API
+// New creates a new client to Lotus API.
 func New(maddr ma.Multiaddr, authToken string, connRetries int) (*apistruct.FullNodeStruct, func(), error) {
 	addr, err := util.TCPAddrFromMultiAddr(maddr)
 	if err != nil {
@@ -60,7 +60,6 @@ func New(maddr ma.Multiaddr, authToken string, connRetries int) (*apistruct.Full
 		cancel()
 		closer()
 	}, nil
-
 }
 
 func monitorLotusSync(ctx context.Context, c *apistruct.FullNodeStruct) {

--- a/net/interface.go
+++ b/net/interface.go
@@ -7,26 +7,26 @@ import (
 	"github.com/textileio/powergate/iplocation"
 )
 
-// Connectedness signals the capacity for a connection with a given node
+// Connectedness signals the capacity for a connection with a given node.
 type Connectedness int
 
 const (
-	// Unspecified means unable to determine connectedness
+	// Unspecified means unable to determine connectedness.
 	Unspecified Connectedness = iota
 
-	// NotConnected means no connection to peer, and no extra information (default)
+	// NotConnected means no connection to peer, and no extra information (default).
 	NotConnected
 
-	// Connected means has an open, live connection to peer
+	// Connected means has an open, live connection to peer.
 	Connected
 
-	// CanConnect means recently connected to peer, terminated gracefully
+	// CanConnect means recently connected to peer, terminated gracefully.
 	CanConnect
 
 	// CannotConnect means recently attempted connecting but failed to connect.
 	CannotConnect
 
-	// Error means there was an error determining connectedness
+	// Error means there was an error determining connectedness.
 	Error
 )
 
@@ -45,24 +45,24 @@ func (s Connectedness) String() string {
 	return names[s]
 }
 
-// PeerInfo provides address info and location info about a peer
+// PeerInfo provides address info and location info about a peer.
 type PeerInfo struct {
 	AddrInfo peer.AddrInfo
 	Location *iplocation.Location
 }
 
-//Module defines the net API
+//Module defines the net API.
 type Module interface {
-	// ListenAddr returns listener address info for the local node
+	// ListenAddr returns listener address info for the local node.
 	ListenAddr(context.Context) (peer.AddrInfo, error)
-	// Peers returns a list of peers
+	// Peers returns a list of peers.
 	Peers(context.Context) ([]PeerInfo, error)
 	// FindPeer finds a peer by peer id
 	FindPeer(context.Context, peer.ID) (PeerInfo, error)
-	// ConnectPeer connects to a peer
+	// ConnectPeer connects to a peer.
 	ConnectPeer(context.Context, peer.AddrInfo) error
-	// DisconnectPeer disconnects from a peer
+	// DisconnectPeer disconnects from a peer.
 	DisconnectPeer(context.Context, peer.ID) error
-	// Connectedness returns the connection status to a peer
+	// Connectedness returns the connection status to a peer.
 	Connectedness(context.Context, peer.ID) (Connectedness, error)
 }

--- a/net/lotus/module.go
+++ b/net/lotus/module.go
@@ -23,7 +23,7 @@ type Module struct {
 	lr  iplocation.LocationResolver
 }
 
-// New creates a new net module
+// New creates a new net module.
 func New(api *apistruct.FullNodeStruct, lr iplocation.LocationResolver) *Module {
 	m := &Module{
 		api: api,
@@ -32,22 +32,22 @@ func New(api *apistruct.FullNodeStruct, lr iplocation.LocationResolver) *Module 
 	return m
 }
 
-// ListenAddr implements ListenAddr
+// ListenAddr implements ListenAddr.
 func (m *Module) ListenAddr(ctx context.Context) (peer.AddrInfo, error) {
 	return m.api.NetAddrsListen(ctx)
 }
 
-// ConnectPeer implements ConnectPeer
+// ConnectPeer implements ConnectPeer.
 func (m *Module) ConnectPeer(ctx context.Context, addrInfo peer.AddrInfo) error {
 	return m.api.NetConnect(ctx, addrInfo)
 }
 
-// DisconnectPeer implements DisconnectPeer
+// DisconnectPeer implements DisconnectPeer.
 func (m *Module) DisconnectPeer(ctx context.Context, peerID peer.ID) error {
 	return m.api.NetDisconnect(ctx, peerID)
 }
 
-// FindPeer implements FindPeer
+// FindPeer implements FindPeer.
 func (m *Module) FindPeer(ctx context.Context, peerID peer.ID) (net.PeerInfo, error) {
 	addrInfo, err := m.api.NetFindPeer(ctx, peerID)
 	if err != nil {
@@ -68,7 +68,7 @@ func (m *Module) FindPeer(ctx context.Context, peerID peer.ID) (net.PeerInfo, er
 	}, nil
 }
 
-// Peers implements Peers
+// Peers implements Peers.
 func (m *Module) Peers(ctx context.Context) ([]net.PeerInfo, error) {
 	addrInfos, err := m.api.NetPeers(ctx)
 	if err != nil {
@@ -94,7 +94,7 @@ func (m *Module) Peers(ctx context.Context) ([]net.PeerInfo, error) {
 	return peerInfos, nil
 }
 
-// Connectedness implements Connectedness
+// Connectedness implements Connectedness.
 func (m *Module) Connectedness(ctx context.Context, peerID peer.ID) (net.Connectedness, error) {
 	con, err := m.api.NetConnectedness(ctx, peerID)
 	if err != nil {

--- a/net/rpc/rpc.go
+++ b/net/rpc/rpc.go
@@ -8,19 +8,19 @@ import (
 	"github.com/textileio/powergate/net"
 )
 
-// RPC implements the rpc service
+// RPC implements the rpc service.
 type RPC struct {
 	UnimplementedRPCServiceServer
 
 	module net.Module
 }
 
-// New creates a new rpc service
+// New creates a new rpc service.
 func New(m net.Module) *RPC {
 	return &RPC{module: m}
 }
 
-// ListenAddr calls module.ListenAddr
+// ListenAddr calls module.ListenAddr.
 func (a *RPC) ListenAddr(ctx context.Context, req *ListenAddrRequest) (*ListenAddrResponse, error) {
 	addrInfo, err := a.module.ListenAddr(ctx)
 	if err != nil {
@@ -40,7 +40,7 @@ func (a *RPC) ListenAddr(ctx context.Context, req *ListenAddrRequest) (*ListenAd
 	}, nil
 }
 
-// Peers calls module.Peers
+// Peers calls module.Peers.
 func (a *RPC) Peers(ctx context.Context, req *PeersRequest) (*PeersResponse, error) {
 	peers, err := a.module.Peers(ctx)
 	if err != nil {
@@ -73,7 +73,7 @@ func (a *RPC) Peers(ctx context.Context, req *PeersRequest) (*PeersResponse, err
 	}, nil
 }
 
-// FindPeer calls module.FindPeer
+// FindPeer calls module.FindPeer.
 func (a *RPC) FindPeer(ctx context.Context, req *FindPeerRequest) (*FindPeerResponse, error) {
 	peerID, err := peer.Decode(req.PeerId)
 	if err != nil {
@@ -104,7 +104,7 @@ func (a *RPC) FindPeer(ctx context.Context, req *FindPeerRequest) (*FindPeerResp
 	}, nil
 }
 
-// ConnectPeer calls module.ConnectPeer
+// ConnectPeer calls module.ConnectPeer.
 func (a *RPC) ConnectPeer(ctx context.Context, req *ConnectPeerRequest) (*ConnectPeerResponse, error) {
 	addrs := make([]ma.Multiaddr, len(req.PeerInfo.Addrs))
 	for i, addr := range req.PeerInfo.Addrs {
@@ -132,7 +132,7 @@ func (a *RPC) ConnectPeer(ctx context.Context, req *ConnectPeerRequest) (*Connec
 	return &ConnectPeerResponse{}, nil
 }
 
-// DisconnectPeer calls module.DisconnectPeer
+// DisconnectPeer calls module.DisconnectPeer.
 func (a *RPC) DisconnectPeer(ctx context.Context, req *DisconnectPeerRequest) (*DisconnectPeerResponse, error) {
 	peerID, err := peer.Decode(req.PeerId)
 	if err != nil {
@@ -146,7 +146,7 @@ func (a *RPC) DisconnectPeer(ctx context.Context, req *DisconnectPeerRequest) (*
 	return &DisconnectPeerResponse{}, nil
 }
 
-// Connectedness calls module.Connectedness
+// Connectedness calls module.Connectedness.
 func (a *RPC) Connectedness(ctx context.Context, req *ConnectednessRequest) (*ConnectednessResponse, error) {
 	peerID, err := peer.Decode(req.PeerId)
 	if err != nil {

--- a/paych/lotus/module.go
+++ b/paych/lotus/module.go
@@ -12,21 +12,21 @@ import (
 	"github.com/textileio/powergate/ffs"
 )
 
-// Module provides access to the paych api
+// Module provides access to the paych api.
 type Module struct {
 	api *apistruct.FullNodeStruct
 }
 
 var _ ffs.PaychManager = (*Module)(nil)
 
-// New creates a new paych module
+// New creates a new paych module.
 func New(api *apistruct.FullNodeStruct) *Module {
 	return &Module{
 		api: api,
 	}
 }
 
-// List lists all payment channels involving the specified addresses
+// List lists all payment channels involving the specified addresses.
 func (m *Module) List(ctx context.Context, addrs ...string) ([]ffs.PaychInfo, error) {
 	filter := make(map[string]struct{}, len(addrs))
 	for _, addr := range addrs {
@@ -91,7 +91,7 @@ func (m *Module) List(ctx context.Context, addrs ...string) ([]ffs.PaychInfo, er
 	return final, nil
 }
 
-// Create creates a new payment channel
+// Create creates a new payment channel.
 func (m *Module) Create(ctx context.Context, from string, to string, amount uint64) (ffs.PaychInfo, cid.Cid, error) {
 	return ffs.PaychInfo{}, cid.Undef, fmt.Errorf("unimplemeted for now, blocked by lotus issue #1611")
 	// fAddr, err := address.NewFromString(from)
@@ -116,7 +116,7 @@ func (m *Module) Create(ctx context.Context, from string, to string, amount uint
 	// return res, info.ChannelMessage, nil
 }
 
-// Redeem redeems a payment channel
+// Redeem redeems a payment channel.
 func (m *Module) Redeem(ctx context.Context, ch string) error {
 	chAddr, err := address.NewFromString(ch)
 	if err != nil {

--- a/reputation/internal/source/source.go
+++ b/reputation/internal/source/source.go
@@ -7,7 +7,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-// Source is an external source of reputation information
+// Source is an external source of reputation information.
 type Source struct {
 	ID          string
 	Weight      float64
@@ -16,7 +16,7 @@ type Source struct {
 	LastFetched *time.Time
 }
 
-// Refresh pulls fresh information from source
+// Refresh pulls fresh information from source.
 func (s *Source) Refresh(ctx context.Context) error {
 	// ToDo: pull from Maddr fresh reputation information
 	return nil

--- a/reputation/internal/source/store.go
+++ b/reputation/internal/source/store.go
@@ -20,19 +20,19 @@ var (
 	baseKey = datastore.NewKey("/reputation/store")
 )
 
-// Store contains Sources information
+// Store contains Sources information.
 type Store struct {
 	ds datastore.TxnDatastore
 }
 
-// NewStore returns a new SourceStore
+// NewStore returns a new SourceStore.
 func NewStore(ds datastore.TxnDatastore) *Store {
 	return &Store{
 		ds: ds,
 	}
 }
 
-// Add adds a new Source to the store
+// Add adds a new Source to the store.
 func (ss *Store) Add(s Source) error {
 	txn, err := ss.ds.NewTransaction(false)
 	if err != nil {
@@ -51,7 +51,7 @@ func (ss *Store) Add(s Source) error {
 	return ss.put(txn, s)
 }
 
-// Update updates a Source
+// Update updates a Source.
 func (ss *Store) Update(s Source) error {
 	txn, err := ss.ds.NewTransaction(false)
 	if err != nil {
@@ -68,7 +68,7 @@ func (ss *Store) Update(s Source) error {
 	return ss.put(txn, s)
 }
 
-// GetAll returns all Sources
+// GetAll returns all Sources.
 func (ss *Store) GetAll() ([]Source, error) {
 	txn, err := ss.ds.NewTransaction(true)
 	if err != nil {
@@ -105,7 +105,6 @@ func (ss *Store) put(txn datastore.Txn, s Source) error {
 		return err
 	}
 	return txn.Commit()
-
 }
 
 func genKey(id string) datastore.Key {

--- a/reputation/reputation.go
+++ b/reputation/reputation.go
@@ -24,7 +24,7 @@ var (
 )
 
 // Module consolidates different sources of information to create a
-// reputation rank of FC miners
+// reputation rank of FC miners.
 type Module struct {
 	ds      datastore.TxnDatastore
 	sources *source.Store
@@ -47,13 +47,13 @@ type Module struct {
 	finished chan struct{}
 }
 
-// MinerScore contains a score for a miner
+// MinerScore contains a score for a miner.
 type MinerScore struct {
 	Addr  string
 	Score int
 }
 
-// New returns a new reputation Module
+// New returns a new reputation Module.
 func New(ds datastore.TxnDatastore, mi *miner.Index, si *faults.Index, ai *askRunner.Runner) *Module {
 	ctx, cancel := context.WithCancel(context.Background())
 	rm := &Module{
@@ -76,7 +76,7 @@ func New(ds datastore.TxnDatastore, mi *miner.Index, si *faults.Index, ai *askRu
 	return rm
 }
 
-// AddSource adds a new external Source to be considered for reputation generation
+// AddSource adds a new external Source to be considered for reputation generation.
 func (rm *Module) AddSource(id string, maddr ma.Multiaddr) error {
 	return rm.sources.Add(source.Source{ID: id, Maddr: maddr})
 }
@@ -86,6 +86,7 @@ func (rm *Module) AddSource(id string, maddr ma.Multiaddr) error {
 func (rm *Module) QueryMiners(excludedMiners []string, countryCodes []string, trustedMiners []string) ([]MinerScore, error) {
 	rm.lockScores.Lock()
 	defer rm.lockScores.Unlock()
+
 	var mr []MinerScore
 	pmr := make(map[string]struct{})
 	for _, tm := range trustedMiners {
@@ -133,7 +134,7 @@ func (rm *Module) QueryMiners(excludedMiners []string, countryCodes []string, tr
 	return mr, nil
 }
 
-// GetTopMiners gets the top n miners with best score
+// GetTopMiners gets the top n miners with best score.
 func (rm *Module) GetTopMiners(n int) ([]MinerScore, error) {
 	if n < 1 {
 		return nil, fmt.Errorf("the number of miners should be greater than zero")
@@ -150,14 +151,14 @@ func (rm *Module) GetTopMiners(n int) ([]MinerScore, error) {
 	return mr, nil
 }
 
-// Close closes the reputation Module
+// Close closes the reputation Module.
 func (rm *Module) Close() error {
 	rm.cancel()
 	<-rm.finished
 	return nil
 }
 
-// subscribeIndexes listen to all sources changes to trigger score regeneration
+// subscribeIndexes listen to all sources changes to trigger score regeneration.
 func (rm *Module) subscribeIndexes() {
 	defer close(rm.finished)
 	subMi := rm.mi.Listen()
@@ -187,7 +188,7 @@ func (rm *Module) subscribeIndexes() {
 	}
 }
 
-// indexBuilder regenerates score information from all known sources
+// indexBuilder regenerates score information from all known sources.
 func (rm *Module) indexBuilder() {
 	for range rm.rebuild {
 		log.Info("rebuilding index")
@@ -221,7 +222,7 @@ func (rm *Module) indexBuilder() {
 	}
 }
 
-// calculateScore calculates the score for a miner
+// calculateScore calculates the score for a miner.
 func calculateScore(addr string, mi miner.IndexSnapshot, si faults.IndexSnapshot, ai ask.Index, ss []source.Source) MinerScore {
 	miner := mi.OnChain.Miners[addr]
 	powerScore := miner.RelativePower

--- a/reputation/rpc/rpc.go
+++ b/reputation/rpc/rpc.go
@@ -7,21 +7,21 @@ import (
 	"github.com/textileio/powergate/reputation"
 )
 
-// RPC implements the gprc service
+// RPC implements the gprc service.
 type RPC struct {
 	UnimplementedRPCServiceServer
 
 	module *reputation.Module
 }
 
-// New creates a new rpc service
+// New creates a new rpc service.
 func New(m *reputation.Module) *RPC {
 	return &RPC{
 		module: m,
 	}
 }
 
-// AddSource calls Module.AddSource
+// AddSource calls Module.AddSource.
 func (s *RPC) AddSource(ctx context.Context, req *AddSourceRequest) (*AddSourceResponse, error) {
 	maddr, err := ma.NewMultiaddr(req.GetMaddr())
 	if err != nil {
@@ -33,7 +33,7 @@ func (s *RPC) AddSource(ctx context.Context, req *AddSourceRequest) (*AddSourceR
 	return &AddSourceResponse{}, nil
 }
 
-// GetTopMiners calls Module.GetTopMiners
+// GetTopMiners calls Module.GetTopMiners.
 func (s *RPC) GetTopMiners(ctx context.Context, req *GetTopMinersRequest) (*GetTopMinersResponse, error) {
 	minerScores, err := s.module.GetTopMiners(int(req.GetLimit()))
 	if err != nil {

--- a/scripts/gen-js-protos.sh
+++ b/scripts/gen-js-protos.sh
@@ -19,8 +19,8 @@ mkdir -p $PTOTOC_GEN_OUT_DIR
 
 printf '{"name":"%s", "version":"%s", "files":["%s"]}' $LIB_NAME $LIB_VERSION $LIB_SRC_DIR > $OUT_PATH/package.json
 
-(cd $OUT_PATH && npm install --save-dev ts-protoc-gen @types/google-protobuf)
-(cd $OUT_PATH && npm install google-protobuf @improbable-eng/grpc-web)
+(cd $OUT_PATH && npm install --save-dev ts-protoc-gen)
+(cd $OUT_PATH && npm install google-protobuf @improbable-eng/grpc-web @types/google-protobuf)
 
 ABS_OUT_PATH="$( cd $OUT_PATH >/dev/null 2>&1 ; pwd -P )"
 ABS_PROTOS_PATH="$( cd $PROTOS_PATH >/dev/null 2>&1 ; pwd -P )"

--- a/signaler/signaler.go
+++ b/signaler/signaler.go
@@ -10,18 +10,18 @@ var (
 	log = logging.Logger("broadcaster")
 )
 
-// Signaler allows subscribing to a singnaling hub
+// Signaler allows subscribing to a singnaling hub.
 type Signaler struct {
 	lock      sync.Mutex
 	listeners []chan struct{}
 }
 
-// New returns a new Signaler
+// New returns a new Signaler.
 func New() *Signaler {
 	return &Signaler{}
 }
 
-// Listen returns a new channel signaler
+// Listen returns a new channel signaler.
 func (s *Signaler) Listen() <-chan struct{} {
 	c := make(chan struct{}, 1)
 	s.lock.Lock()
@@ -30,7 +30,7 @@ func (s *Signaler) Listen() <-chan struct{} {
 	return c
 }
 
-// Unregister unregisters a channel signaler from the hub
+// Unregister unregisters a channel signaler from the hub.
 func (s *Signaler) Unregister(c chan struct{}) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -48,7 +48,7 @@ func (s *Signaler) Unregister(c chan struct{}) {
 	}
 }
 
-// Signal triggers a new notification to all listeners
+// Signal triggers a new notification to all listeners.
 func (s *Signaler) Signal() {
 	s.lock.Lock()
 	defer s.lock.Unlock()

--- a/tests/ldevnet.go
+++ b/tests/ldevnet.go
@@ -17,7 +17,7 @@ import (
 	"github.com/textileio/powergate/util"
 )
 
-// LaunchDevnetDocker launches the devnet docker image
+// LaunchDevnetDocker launches the devnet docker image.
 func LaunchDevnetDocker(t *testing.T, numMiners int, ipfsMaddr string) *dockertest.Resource {
 	pool, err := dockertest.NewPool("")
 	if err != nil {

--- a/tests/ldevnet.go
+++ b/tests/ldevnet.go
@@ -30,7 +30,7 @@ func LaunchDevnetDocker(t *testing.T, numMiners int, ipfsMaddr string) *dockerte
 	}
 	repository := "textile/lotus-devnet"
 	tag := "sha-f8988b8"
-	lotusDevnet, err := pool.RunWithOptions(&dockertest.RunOptions{Repository: repository, Tag: tag, Env: envs, Mounts: []string{"/tmp/powergate:/tmp/powergate"}})
+	lotusDevnet, err := pool.RunWithOptions(&dockertest.RunOptions{Repository: repository, Tag: tag, Env: envs})
 	if err != nil {
 		panic(fmt.Sprintf("couldn't run lotus-devnet container: %s", err))
 	}

--- a/tests/ldevnet.go
+++ b/tests/ldevnet.go
@@ -18,7 +18,7 @@ import (
 )
 
 // LaunchDevnetDocker launches the devnet docker image.
-func LaunchDevnetDocker(t *testing.T, numMiners int, ipfsMaddr string) *dockertest.Resource {
+func LaunchDevnetDocker(t *testing.T, numMiners int, ipfsMaddr string, mountVolumes bool) *dockertest.Resource {
 	pool, err := dockertest.NewPool("")
 	if err != nil {
 		panic(fmt.Sprintf("couldn't create ipfs-pool: %s", err))
@@ -28,9 +28,14 @@ func LaunchDevnetDocker(t *testing.T, numMiners int, ipfsMaddr string) *dockerte
 		devnetEnv("SPEED", "500"),
 		devnetEnv("IPFSADDR", ipfsMaddr),
 	}
+	var mounts []string
+	if mountVolumes {
+		mounts = append(mounts, "/tmp/powergate:/tmp/powergate")
+	}
+
 	repository := "textile/lotus-devnet"
 	tag := "sha-f8988b8"
-	lotusDevnet, err := pool.RunWithOptions(&dockertest.RunOptions{Repository: repository, Tag: tag, Env: envs})
+	lotusDevnet, err := pool.RunWithOptions(&dockertest.RunOptions{Repository: repository, Tag: tag, Env: envs, Mounts: mounts})
 	if err != nil {
 		panic(fmt.Sprintf("couldn't run lotus-devnet container: %s", err))
 	}
@@ -69,8 +74,8 @@ func LaunchDevnetDocker(t *testing.T, numMiners int, ipfsMaddr string) *dockerte
 }
 
 // CreateLocalDevnetWithIPFS creates a local devnet connected to an IPFS node.
-func CreateLocalDevnetWithIPFS(t *testing.T, numMiners int, ipfsMaddr string) (*apistruct.FullNodeStruct, address.Address, []address.Address) {
-	lotusDevnet := LaunchDevnetDocker(t, numMiners, ipfsMaddr)
+func CreateLocalDevnetWithIPFS(t *testing.T, numMiners int, ipfsMaddr string, mountVolumes bool) (*apistruct.FullNodeStruct, address.Address, []address.Address) {
+	lotusDevnet := LaunchDevnetDocker(t, numMiners, ipfsMaddr, mountVolumes)
 	c, cls, err := lotus.New(util.MustParseAddr("/ip4/127.0.0.1/tcp/"+lotusDevnet.GetPort("7777/tcp")), "", 1)
 	if err != nil {
 		panic(err)
@@ -93,7 +98,7 @@ func CreateLocalDevnetWithIPFS(t *testing.T, numMiners int, ipfsMaddr string) (*
 // CreateLocalDevnet returns an API client that targets a local devnet with numMiners number
 // of miners. Refer to http://github.com/textileio/local-devnet for more information.
 func CreateLocalDevnet(t *testing.T, numMiners int) (*apistruct.FullNodeStruct, address.Address, []address.Address) {
-	return CreateLocalDevnetWithIPFS(t, numMiners, "")
+	return CreateLocalDevnetWithIPFS(t, numMiners, "", true)
 }
 
 func devnetEnv(name string, value interface{}) string {

--- a/tests/mocks/mocks.go
+++ b/tests/mocks/mocks.go
@@ -11,30 +11,30 @@ import (
 
 var _ miner.P2PHost = (*P2pHostMock)(nil)
 
-// P2pHostMock provides a mock P2PHost
+// P2pHostMock provides a mock P2PHost.
 type P2pHostMock struct{}
 
-// Addrs implements Addrs
+// Addrs implements Addrs.
 func (hm *P2pHostMock) Addrs(id peer.ID) []multiaddr.Multiaddr {
 	return nil
 }
 
-// GetAgentVersion implements GetAgentVersion
+// GetAgentVersion implements GetAgentVersion.
 func (hm *P2pHostMock) GetAgentVersion(id peer.ID) string {
 	return "fakeAgentVersion"
 }
 
-// Ping implements Ping
+// Ping implements Ping.
 func (hm *P2pHostMock) Ping(ctx context.Context, pid peer.ID) bool {
 	return true
 }
 
 var _ iplocation.LocationResolver = (*LrMock)(nil)
 
-// LrMock provides a mock LocationResolver
+// LrMock provides a mock LocationResolver.
 type LrMock struct{}
 
-// Resolve implements Resolve
+// Resolve implements Resolve.
 func (lr *LrMock) Resolve(mas []multiaddr.Multiaddr) (iplocation.Location, error) {
 	return iplocation.Location{
 		Country:   "USA",

--- a/tests/txmapds.go
+++ b/tests/txmapds.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ipfs/go-datastore/query"
 )
 
-// TxMapDatastore is a in-memory datastore that satisfies TxnDatastore
+// TxMapDatastore is a in-memory datastore that satisfies TxnDatastore.
 type TxMapDatastore struct {
 	*datastore.MapDatastore
 	lock sync.RWMutex
@@ -86,7 +86,7 @@ type op struct {
 }
 
 // SimpleTx implements the transaction interface for datastores who do
-// not have any sort of underlying transactional support
+// not have any sort of underlying transactional support.
 type SimpleTx struct {
 	ops    map[datastore.Key]op
 	lock   sync.RWMutex

--- a/txndstransform/txndstransform.go
+++ b/txndstransform/txndstransform.go
@@ -8,7 +8,7 @@ import (
 	dsq "github.com/ipfs/go-datastore/query"
 )
 
-// Wrap wraps a TxDatastore with a namespace prefix
+// Wrap wraps a TxDatastore with a namespace prefix.
 func Wrap(child ds.TxnDatastore, prefix string) *Datastore {
 	parts := strings.Split(prefix, "/")
 	prefixKey := ds.NewKey("/")
@@ -24,7 +24,7 @@ func Wrap(child ds.TxnDatastore, prefix string) *Datastore {
 	return nds
 }
 
-// Datastore keeps a KeyTransform function
+// Datastore keeps a KeyTransform function.
 type Datastore struct {
 	child ds.TxnDatastore
 	kt.KeyTransform
@@ -36,7 +36,7 @@ type txn struct {
 	ds *Datastore
 }
 
-// NewTransaction returns a transaction wrapped by the selected namespace prefix
+// NewTransaction returns a transaction wrapped by the selected namespace prefix.
 func (d *Datastore) NewTransaction(readOnly bool) (ds.Txn, error) {
 	t, err := d.child.NewTransaction(readOnly)
 	if err != nil {
@@ -59,7 +59,7 @@ func (t *txn) Put(key ds.Key, value []byte) (err error) {
 	return t.Txn.Put(t.ds.ConvertKey(key), value)
 }
 
-// Delete removes the value for given key
+// Delete removes the value for given key.
 func (t *txn) Delete(key ds.Key) (err error) {
 	return t.Txn.Delete(t.ds.ConvertKey(key))
 }
@@ -111,7 +111,6 @@ func (t *txn) Query(q dsq.Query) (dsq.Results, error) {
 // Split the query into a child query and a naive query. That way, we can make
 // the child datastore do as much work as possible.
 func (t *txn) prepareQuery(q dsq.Query) (naive, child dsq.Query) {
-
 	// First, put everything in the child query. Then, start taking things
 	// out.
 	child = q

--- a/util/util.go
+++ b/util/util.go
@@ -15,7 +15,7 @@ var (
 	AvgBlockTime = time.Second * 30
 )
 
-// TCPAddrFromMultiAddr converts a multiaddress to a string representation of a tcp address
+// TCPAddrFromMultiAddr converts a multiaddress to a string representation of a tcp address.
 func TCPAddrFromMultiAddr(maddr ma.Multiaddr) (addr string, err error) {
 	if maddr == nil {
 		err = fmt.Errorf("invalid address")

--- a/wallet/rpc/rpc.go
+++ b/wallet/rpc/rpc.go
@@ -6,19 +6,19 @@ import (
 	"github.com/textileio/powergate/wallet"
 )
 
-// RPC implements the gprc service
+// RPC implements the gprc service.
 type RPC struct {
 	UnimplementedRPCServiceServer
 
 	Module *wallet.Module
 }
 
-// New creates a new rpc service
+// New creates a new rpc service.
 func New(m *wallet.Module) *RPC {
 	return &RPC{Module: m}
 }
 
-// NewAddress creates a new wallet
+// NewAddress creates a new wallet.
 func (s *RPC) NewAddress(ctx context.Context, req *NewAddressRequest) (*NewAddressResponse, error) {
 	res, err := s.Module.NewAddress(ctx, req.GetType())
 	if err != nil {
@@ -27,7 +27,7 @@ func (s *RPC) NewAddress(ctx context.Context, req *NewAddressRequest) (*NewAddre
 	return &NewAddressResponse{Address: res}, nil
 }
 
-// WalletBalance checks a wallet balance
+// WalletBalance checks a wallet balance.
 func (s *RPC) WalletBalance(ctx context.Context, req *WalletBalanceRequest) (*WalletBalanceResponse, error) {
 	res, err := s.Module.Balance(ctx, req.GetAddress())
 	if err != nil {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -18,7 +18,7 @@ type Module struct {
 	masterAddr address.Address
 }
 
-// New creates a new wallet module
+// New creates a new wallet module.
 func New(api *apistruct.FullNodeStruct, maddr address.Address, iam big.Int) (*Module, error) {
 	m := &Module{
 		api:        api,
@@ -28,7 +28,7 @@ func New(api *apistruct.FullNodeStruct, maddr address.Address, iam big.Int) (*Mo
 	return m, nil
 }
 
-// NewAddress creates a new address
+// NewAddress creates a new address.
 func (m *Module) NewAddress(ctx context.Context, typ string) (string, error) {
 	var ty crypto.SigType
 	if typ == "bls" {
@@ -75,7 +75,7 @@ func (m *Module) Balance(ctx context.Context, addr string) (uint64, error) {
 	return b.Uint64(), nil
 }
 
-// SendFil sends fil from one address to another
+// SendFil sends fil from one address to another.
 func (m *Module) SendFil(ctx context.Context, from string, to string, amount *big.Int) error {
 	f, err := address.NewFromString(from)
 	if err != nil {


### PR DESCRIPTION
- Since we made the integration of Lotus and IPFS, Powergate FFS doesn't need to share filesystem volumes with Lotus. I removed them from docker-compose-devnet, and the integrationtests, just to enforce nothing is shared.
- Leave the mount configurable since tests using directly the Deals module should share volumes, as they need to import data to the Lotus node in scenarios where that conectedness isn't necessary.
- Enable a bunch of new linters which are quite useful, mostly one to detect unused parameters which revealed some interesting situations which were fixed.