### PR TITLE
ffs: ProposalCid undefined correct handling

### DIFF
--- a/api/client/ffs.go
+++ b/api/client/ffs.go
@@ -607,7 +607,7 @@ func fromRPCDealErrors(des []*rpc.DealError) ([]ffs.DealError, error) {
 	res := make([]ffs.DealError, len(des))
 	for i, de := range des {
 		var propCid cid.Cid
-		if de.ProposalCid != "" {
+		if de.ProposalCid != "" && de.ProposalCid != "b" {
 			var err error
 			propCid, err = cid.Decode(de.ProposalCid)
 			if err != nil {

--- a/deals/rpc/rpc.go
+++ b/deals/rpc/rpc.go
@@ -139,8 +139,12 @@ func (s *RPC) Watch(req *WatchRequest, srv RPCService_WatchServer) error {
 	}
 
 	for update := range ch {
+		var strProposalCid string
+		if update.ProposalCid.Defined() {
+			strProposalCid = update.ProposalCid.String()
+		}
 		dealInfo := &DealInfo{
-			ProposalCid:   update.ProposalCid.String(),
+			ProposalCid:   strProposalCid,
 			StateId:       update.StateID,
 			StateName:     update.StateName,
 			Miner:         update.Miner,

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1203,7 +1203,7 @@ func TestFailedJobMessage(t *testing.T) {
 	require.NotEmpty(t, job.ErrCause)
 	require.Len(t, job.DealErrors, 1)
 	de := job.DealErrors[0]
-	require.NotEmpty(t, de.ProposalCid.String())
+	require.True(t, de.ProposalCid.Defined())
 	require.NotEmpty(t, de.Miner)
 	require.Equal(t, "failed to start deal: cannot propose a deal whose piece size (4096) is greater than sector size (2048)", de.Message)
 }

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1203,7 +1203,7 @@ func TestFailedJobMessage(t *testing.T) {
 	require.NotEmpty(t, job.ErrCause)
 	require.Len(t, job.DealErrors, 1)
 	de := job.DealErrors[0]
-	require.True(t, de.ProposalCid.Defined())
+	require.False(t, de.ProposalCid.Defined())
 	require.NotEmpty(t, de.Miner)
 	require.Equal(t, "failed to start deal: cannot propose a deal whose piece size (4096) is greater than sector size (2048)", de.Message)
 }

--- a/ffs/rpc/rpc.go
+++ b/ffs/rpc/rpc.go
@@ -647,8 +647,12 @@ func toRPCColdConfig(config ffs.ColdConfig) *ColdConfig {
 func toRPCDealErrors(des []ffs.DealError) []*DealError {
 	ret := make([]*DealError, len(des))
 	for i, de := range des {
+		var strProposalCid string
+		if de.ProposalCid.Defined() {
+			strProposalCid = de.ProposalCid.String()
+		}
 		ret[i] = &DealError{
-			ProposalCid: de.ProposalCid.String(),
+			ProposalCid: strProposalCid,
 			Miner:       de.Miner,
 			Message:     de.Message,
 		}
@@ -718,8 +722,12 @@ func toRPCCidInfo(info ffs.CidInfo) *CidInfo {
 		},
 	}
 	for i, p := range info.Cold.Filecoin.Proposals {
+		var strProposalCid string
+		if p.ProposalCid.Defined() {
+			strProposalCid = p.ProposalCid.String()
+		}
 		cidInfo.Cold.Filecoin.Proposals[i] = &FilStorage{
-			ProposalCid:     p.ProposalCid.String(),
+			ProposalCid:     strProposalCid,
 			Renewed:         p.Renewed,
 			Duration:        p.Duration,
 			ActivationEpoch: p.ActivationEpoch,


### PR DESCRIPTION
So the new linters from past PR already uncovered an edge behavior.
In short, if a `cid.Cid` is `cid.Undef`, then it's stringified value is `b`, not empty. 

This was discovered by upgrading `textile` PG version, in an integration test testing a failure scenario.