### PR TITLE
update Dockerfile path

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          dockerfile: cmd/powd/Dockerfile
+          dockerfile: .
           repository: textile/powergate
           tag_with_ref: true
           tag_with_sha: true


### PR DESCRIPTION
Since the `Dockerfile` was moved, the GH action that pushes to DockerHub on each merge should change.