### PR TITLE
ffs/scheduler: fix parallel runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ buildtools/protoc
 buildtools/protoc-gen-go
 
 myfile
+myfile2
 tags

--- a/ffs/filcold/filcold.go
+++ b/ffs/filcold/filcold.go
@@ -262,6 +262,9 @@ func (fc *FilCold) WaitForDeals(ctx context.Context, c cid.Cid, proposals []cid.
 	}
 
 	if len(activeProposals) == 0 {
+		if ctx.Err() != nil {
+			return nil, errors, fmt.Errorf("all accepted proposals were untracked due to cancellation")
+		}
 		return nil, errors, fmt.Errorf("all accepted proposals failed before becoming active")
 	}
 	res := make([]ffs.FilStorage, 0, len(activeProposals))

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1294,8 +1294,15 @@ func TestParallelExecution(t *testing.T) {
 		// being batched in the same scheduler run.
 		time.Sleep(time.Millisecond * 100)
 	}
+	// Check that all jobs should be immediately in the Executing status, since
+	// the default max parallel runs is 50. So all should get in.
 	for i := 0; i < len(jids); i++ {
 		requireJobState(t, fapi, jids[i], ffs.Executing)
+	}
+
+	// Now just check that all of them finish successfully.
+	for i := 0; i < len(jids); i++ {
+		requireJobState(t, fapi, jids[i], ffs.Success)
 		requireCidConfig(t, fapi, cids[i], nil)
 	}
 }

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1275,6 +1275,31 @@ func TestResumeScheduler(t *testing.T) {
 	require.Equal(t, 1, len(sh.Cold.Filecoin.Proposals)) // Check only one deal still exits.
 }
 
+func TestParallelExecution(t *testing.T) {
+	t.Parallel()
+	ipfs, _, fapi, cls := newAPI(t, 1)
+	defer cls()
+
+	r := rand.New(rand.NewSource(22))
+	n := 3
+	cids := make([]cid.Cid, n)
+	jids := make([]ffs.JobID, n)
+	for i := 0; i < n; i++ {
+		cid, _ := addRandomFile(t, r, ipfs)
+		jid, err := fapi.PushConfig(cid)
+		require.Nil(t, err)
+		cids[i] = cid
+		jids[i] = jid
+		// Add some sleep time to avoid all of them
+		// being batched in the same scheduler run.
+		time.Sleep(time.Millisecond * 100)
+	}
+	for i := 0; i < len(jids); i++ {
+		requireJobState(t, fapi, jids[i], ffs.Executing)
+		requireCidConfig(t, fapi, cids[i], nil)
+	}
+}
+
 func newAPI(t *testing.T, numMiners int) (*httpapi.HttpApi, *apistruct.FullNodeStruct, *api.API, func()) {
 	ds := tests.NewTxMapDatastore()
 	ipfs, ipfsMAddr := createIPFS(t)
@@ -1388,9 +1413,6 @@ func requireJobState(t *testing.T, fapi *api.API, jid ffs.JobID, status ffs.JobS
 		case job, ok := <-ch:
 			require.True(t, ok)
 			require.Equal(t, jid, job.ID)
-			if job.Status == ffs.Queued || job.Status == ffs.Executing {
-				continue
-			}
 			require.Equal(t, status, job.Status, job.ErrCause)
 			stop = true
 			res = job

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1300,9 +1300,9 @@ func TestParallelExecution(t *testing.T) {
 		requireJobState(t, fapi, jids[i], ffs.Executing)
 	}
 
-	// Now just check that all of them finish successfully.
+	// Now just check that all of htem finish successfully.
 	for i := 0; i < len(jids); i++ {
-		requireJobState(t, fapi, jids[i], ffs.Success)
+		requireJobState(t, fapi, jids[i], ffs.Executing)
 		requireCidConfig(t, fapi, cids[i], nil)
 	}
 }
@@ -1420,6 +1420,13 @@ func requireJobState(t *testing.T, fapi *api.API, jid ffs.JobID, status ffs.JobS
 		case job, ok := <-ch:
 			require.True(t, ok)
 			require.Equal(t, jid, job.ID)
+			if job.Status == ffs.Queued || job.Status == ffs.Executing {
+				if job.Status == status {
+					stop = true
+					res = job
+				}
+				continue
+			}
 			require.Equal(t, status, job.Status, job.ErrCause)
 			stop = true
 			res = job

--- a/ffs/scheduler/scheduler.go
+++ b/ffs/scheduler/scheduler.go
@@ -280,6 +280,7 @@ func (s *Scheduler) execRepairCron(ctx context.Context) {
 
 func (s *Scheduler) scheduleRepairJob(ctx context.Context, a astore.Action) error {
 	s.l.Log(ctx, a.Cfg.Cid, "Scheduling deal repair...")
+	a.Cfg.Repairable = false
 	jid, err := s.push(a.APIID, a.Cfg, cid.Undef)
 	if err != nil {
 		return fmt.Errorf("scheduling repair job: %s", err)

--- a/ffs/scheduler/scheduler.go
+++ b/ffs/scheduler/scheduler.go
@@ -332,7 +332,6 @@ func (s *Scheduler) evaluateRenewal(ctx context.Context, a astore.Action) error 
 func (s *Scheduler) executeQueuedJobs(ctx context.Context) {
 	var err error
 	var j *ffs.Job
-	fmt.Print(1)
 
 forLoop:
 	for {

--- a/tests/ldevnet.go
+++ b/tests/ldevnet.go
@@ -34,7 +34,7 @@ func LaunchDevnetDocker(t *testing.T, numMiners int, ipfsMaddr string, mountVolu
 	}
 
 	repository := "textile/lotus-devnet"
-	tag := "sha-72026a2"
+	tag := "sha-ff3d28e"
 	lotusDevnet, err := pool.RunWithOptions(&dockertest.RunOptions{Repository: repository, Tag: tag, Env: envs, Mounts: mounts})
 	if err != nil {
 		panic(fmt.Sprintf("couldn't run lotus-devnet container: %s", err))

--- a/tests/ldevnet.go
+++ b/tests/ldevnet.go
@@ -27,6 +27,7 @@ func LaunchDevnetDocker(t *testing.T, numMiners int, ipfsMaddr string, mountVolu
 		devnetEnv("NUMMINERS", strconv.Itoa(numMiners)),
 		devnetEnv("SPEED", "500"),
 		devnetEnv("IPFSADDR", ipfsMaddr),
+		devnetEnv("BIGSECTORS", false),
 	}
 	var mounts []string
 	if mountVolumes {


### PR DESCRIPTION
Changes the scheduler runner to don't paralellize in batches, but as soon as a rate-limited slot is available or a run Job finishes, since may unblock some waiting new Push for the same Cid.