### PR TITLE
update to devnet that defaults to big sectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,12 +155,16 @@ make devnet
 ```
 This will build Powergate `powd`, a Lotus devnet, a IPFS node and wire them correctly to be ready to use.
 
+**Note**: There also exists a `make devnet-small` command that will create the Lotus devent using 2Kib sectors. This may be more appropriate for certain development or testing scenarios.
+
 Here is a full example of using the devnet run:
 Terminal 1:
 ```bash
 cd docker
 make devnet
 ```
+
+
 Wait for seeing logs about the height of the chain increase in a regular cadence.
 
 Terminal 2:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -10,3 +10,7 @@ up: down
 devnet: 
 	docker-compose -p devnet -f docker-compose-devnet.yaml up --build -V
 .PHONY: devnet
+
+devnet-small: 
+	BIGSECTORS=false docker-compose -p devnet -f docker-compose-devnet.yaml up --build -V
+.PHONY: devnet-small

--- a/docker/docker-compose-devnet.yaml
+++ b/docker/docker-compose-devnet.yaml
@@ -26,10 +26,10 @@ services:
       - 5001:5001
 
   lotus:
-    image: textile/lotus-devnet:sha-72026a2
+    image: textile/lotus-devnet:sha-ff3d28e
     ports:
       - 7777:7777
     environment:
       - TEXLOTUSDEVNET_SPEED=1500
-      - TEXLOTUSDEVNET_BIGSECTORS=true
+      - TEXLOTUSDEVNET_BIGSECTORS=${BIGSECTORS}
       - TEXLOTUSDEVNET_IPFSADDR=/dns4/ipfs/tcp/5001


### PR DESCRIPTION
Adds another `make devnet-small` if you want to start a Devnet with small sectors.