### PR TITLE
feat(builds): adds pow build for linux/darwin to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,68 @@ jobs:
         with:
           files: 'powergate-docker-${{steps.latesttag.outputs.tag}}.zip'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+  release-platform-builds:
+    name: Release Builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Get dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: |
+          export PATH=${PATH}:`go env GOPATH`/bin
+          go get -v -t -d ./...
+      - name: Install gox
+        run: |
+          export PATH=${PATH}:`go env GOPATH`/bin
+          go get github.com/mitchellh/gox  
+      - name: Compile
+        run: |
+          export PATH=${PATH}:`go env GOPATH`/bin
+          gox -osarch="linux/amd64 linux/386 linux/arm darwin/amd64" -output="pow-{{.OS}}-{{.Arch}}" ./cmd/pow
+      - name: Collect artifacts
+        run: |
+          VERSION=${GITHUB_REF##*/}
+          OUT=release/cli
+          mkdir -p ${OUT}
+          mkdir -p tmp
+          cp LICENSE tmp/
+          cp README.md tmp/
+          cp dist/install tmp/
+          cd tmp
+          declare -a arr=("darwin-amd64" "linux-amd64" "linux-386" "linux-arm")
+          for i in "${arr[@]}"
+          do
+              OSARCH=${i%.*}
+              EXT=$([[ "$i" = *.* ]] && echo ".${i##*.}" || echo '')
+              cp ../pow-${i} pow${EXT}
+              if [ "${EXT}" == ".exe" ]; then
+                  zip pow_${VERSION}_${OSARCH}.zip LICENSE README.md pow${EXT}
+                  mv pow_${VERSION}_${OSARCH}.zip ../${OUT}/
+              else
+                  tar -czvf pow_${VERSION}_${OSARCH}.tar.gz LICENSE README.md install pow
+                  mv pow_${VERSION}_${OSARCH}.tar.gz ../${OUT}/
+              fi
+          done
+          cd .. && rm -rf tmp
+          echo $(ls ./release/cli)
+      - name: Upload multiple assets to release
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: 'release/cli/pow_*'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
   publish_grpc_lib:
     name: Publish JS gRPC bindings
     runs-on: ubuntu-latest

--- a/dist/install
+++ b/dist/install
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# From https://github.com/ipfs/go-ipfs/blob/ccef991a194beaedf009b1d0702b1150db3da0a6/cmd/ipfs/dist/install.sh
+#
+# Installation script for powergate. It tries to move $bin in one of the
+# directories stored in $binpaths.
+
+INSTALL_DIR="$(dirname "$0")"
+
+pow="$INSTALL_DIR/pow"
+binpaths="/usr/local/bin /usr/bin"
+
+# This variable contains a nonzero length string in case the script fails
+# because of missing write permissions.
+is_write_perm_missing=""
+
+for binpath in $binpaths; do
+	if mv "$pow" "$binpath/$pow" 2>/dev/null; then
+		echo "Moved $pow to $binpath"
+		exit 0
+	else
+		if test -d "$binpath" && ! test -w "$binpath"; then
+			is_write_perm_missing=1
+		fi
+	fi
+done
+
+echo "We cannot install $pow in one of the directories $binpaths"
+
+if test -n "$is_write_perm_missing"; then
+	echo "It seems that we do not have the necessary write permissions."
+	echo "Perhaps try running this script as a privileged user:"
+	echo
+	echo "    sudo $0"
+	echo
+fi
+
+exit 1


### PR DESCRIPTION
Now that we have release builds anyway, might as well drop the CLI. Realized this in developing the tutorial, that saving the CLI build step can be a nice improvement for teaching. 

@asutula i know you had been thinking about some things here, so hopefully first pass version is okay. ideally we could just have one release out tomorrow for the workshop with builds.