### PR TITLE
Remove unused HotStorage API & use ipfs 0.6.0 & improvements

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -193,7 +193,10 @@ func NewServer(conf Config) (*Server, error) {
 
 	l := cidlogger.New(txndstr.Wrap(ds, "ffs/cidlogger"))
 	cs := filcold.New(ms, dm, ipfs, chain, l)
-	hs := coreipfs.New(ipfs, l)
+	hs, err := coreipfs.New(ipfs, l)
+	if err != nil {
+		return nil, fmt.Errorf("creating coreipfs: %s", err)
+	}
 	sched, err := scheduler.New(txndstr.Wrap(ds, "ffs/scheduler"), l, hs, cs)
 	if err != nil {
 		return nil, fmt.Errorf("creating scheduler: %s", err)

--- a/docker/ipfs-image.yaml
+++ b/docker/ipfs-image.yaml
@@ -3,4 +3,4 @@ version: '3.7'
 services:
 
   ipfs:
-    image: ipfs/go-ipfs:v0.5.1
+    image: ipfs/go-ipfs:v0.6.0

--- a/ffs/coreipfs/coreipfs.go
+++ b/ffs/coreipfs/coreipfs.go
@@ -1,13 +1,11 @@
 package coreipfs
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"sync"
 
-	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	ipfsfiles "github.com/ipfs/go-ipfs-files"
 	logging "github.com/ipfs/go-log/v2"
@@ -39,15 +37,6 @@ func New(ipfs iface.CoreAPI, l ffs.CidLogger) *CoreIpfs {
 		ipfs: ipfs,
 		l:    l,
 	}
-}
-
-// Put saves a Block.
-func (ci *CoreIpfs) Put(ctx context.Context, b blocks.Block) error {
-	log.Debugf("putting block %s", b.Cid())
-	if _, err := ci.ipfs.Block().Put(ctx, bytes.NewReader(b.RawData())); err != nil {
-		return fmt.Errorf("adding block to ipfs node: %s", err)
-	}
-	return nil
 }
 
 // Remove removes a Cid from the Hot Storage.

--- a/ffs/coreipfs/coreipfs.go
+++ b/ffs/coreipfs/coreipfs.go
@@ -58,9 +58,6 @@ func (ci *CoreIpfs) Remove(ctx context.Context, c cid.Cid) error {
 
 // IsStored return if a particular Cid is stored.
 func (ci *CoreIpfs) IsStored(ctx context.Context, c cid.Cid) (bool, error) {
-	if ci.pinset == nil {
-
-	}
 	_, ok := ci.pinset[c]
 	return ok, nil
 }

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1379,7 +1379,8 @@ func newFFSManager(t *testing.T, ds datastore.TxnDatastore, lotusClient *apistru
 	fchain := filchain.New(lotusClient)
 	l := cidlogger.New(txndstr.Wrap(ds, "ffs/cidlogger"))
 	cl := filcold.New(ms, dm, ipfsClient, fchain, l)
-	hl := coreipfs.New(ipfsClient, l)
+	hl, err := coreipfs.New(ipfsClient, l)
+	require.NoError(t, err)
 	sched, err := scheduler.New(txndstr.Wrap(ds, "ffs/scheduler"), l, hl, cl)
 	require.NoError(t, err)
 

--- a/ffs/interfaces.go
+++ b/ffs/interfaces.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"math/big"
 
-	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 )
 
@@ -48,9 +47,6 @@ type HotStorage interface {
 	// Replace replaces a stored Cid with a new one. It's mostly
 	// thought for mutating data doing this efficiently.
 	Replace(context.Context, cid.Cid, cid.Cid) (int, error)
-
-	// Put adds a raw block.
-	Put(context.Context, blocks.Block) error
 
 	// IsStore returns true if the Cid is stored, or false
 	// otherwise.

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -23,7 +23,7 @@ import (
 	"github.com/textileio/powergate/reputation"
 )
 
-const numTopMiners = 30
+const numTopMiners = 100
 
 var log = logger.Logger("gateway")
 


### PR DESCRIPTION
- Remove `Put` API from _HotStorage_ since this was used when Powergate did CAR encodings, which doesn't anymore since we leverage Lotus connecting to IPFS. 
- Changed implementation logic to fill pinset cache once.
- Use IPFS 0.6.0