### PR TITLE
more relevant sorting in gateway data

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -215,7 +215,7 @@ func (g *Gateway) minersHandler(c *gin.Context) {
 	sort.Slice(chainRows, func(i, j int) bool {
 		l := chainRows[i][0].(string)
 		r := chainRows[j][0].(string)
-		return index.OnChain.Miners[l].ActiveDeals >= index.OnChain.Miners[r]
+		return index.OnChain.Miners[l].ActiveDeals >= index.OnChain.Miners[r].ActiveDeals
 	})
 
 	c.HTML(http.StatusOK, "/public/html/miners.gohtml", gin.H{

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -211,6 +212,12 @@ func (g *Gateway) minersHandler(c *gin.Context) {
 		i++
 	}
 
+	sort.Slice(chainRows, func(i, j int) bool {
+		l := chainRows[i][0].(string)
+		r := chainRows[j][0].(string)
+		return index.OnChain.Miners[l].ActiveDeals >= index.OnChain.Miners[r]
+	})
+
 	c.HTML(http.StatusOK, "/public/html/miners.gohtml", gin.H{
 		"MenuItems": menuItems,
 		"MetaData": gin.H{
@@ -250,6 +257,12 @@ func (g *Gateway) faultsHandler(c *gin.Context) {
 		}
 		i++
 	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		l := rows[i][0].(string)
+		r := rows[j][0].(string)
+		return len(index.Miners[l].Epochs) >= len(index.Miners[r].Epochs)
+	})
 
 	c.HTML(http.StatusOK, "/public/html/faults.gohtml", gin.H{
 		"MenuItems": menuItems,


### PR DESCRIPTION
- _Faults index_: It didn't have a defined order, so refreshes have jumping results. Now is ordered by descending order considering the number of faults of miners.
- _Miner On-Chain Data_: Now sorted by descending #ActiveDeals.

Result of the change can be checked already in https://pow.textile.io/
![image](https://user-images.githubusercontent.com/6136245/86494142-7e27f980-bd4a-11ea-86fe-06e6d0179bde.png)

![image](https://user-images.githubusercontent.com/6136245/86494156-8a13bb80-bd4a-11ea-85af-01ca1c014c3c.png)
