### PR TITLE
test: prefer NoError/Error over Nil/NotNil

### DIFF
--- a/api/client/health_test.go
+++ b/api/client/health_test.go
@@ -31,7 +31,7 @@ func TestCheck(t *testing.T) {
 	c, done := setupHealth(t)
 	defer done()
 	status, messages, err := c.Check(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Empty(t, messages)
 	require.Equal(t, h.Ok, status)
 }

--- a/api/client/net_test.go
+++ b/api/client/net_test.go
@@ -12,7 +12,7 @@ func TestListenAddr(t *testing.T) {
 	c, done := setupNet(t)
 	defer done()
 	addrInfo, err := c.ListenAddr(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, addrInfo.Addrs)
 	require.NotEmpty(t, addrInfo.ID)
 }
@@ -21,7 +21,7 @@ func TestPeers(t *testing.T) {
 	c, done := setupNet(t)
 	defer done()
 	peers, err := c.Peers(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, peers)
 }
 
@@ -29,10 +29,10 @@ func TestFindPeer(t *testing.T) {
 	c, done := setupNet(t)
 	defer done()
 	peers, err := c.Peers(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, peers)
 	peer, err := c.FindPeer(ctx, peers[0].AddrInfo.ID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, peer.AddrInfo.ID)
 	require.NotEmpty(t, peer.AddrInfo.Addrs)
 	// The addrs of peers are in localhost, so
@@ -44,22 +44,22 @@ func TestDisconnectConnect(t *testing.T) {
 	c, done := setupNet(t)
 	defer done()
 	peers, err := c.Peers(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, peers)
 	err = c.DisconnectPeer(ctx, peers[0].AddrInfo.ID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = c.ConnectPeer(ctx, peers[0].AddrInfo)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestConnectedness(t *testing.T) {
 	c, done := setupNet(t)
 	defer done()
 	peers, err := c.Peers(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, peers)
 	connectedness, err := c.Connectedness(ctx, peers[0].AddrInfo.ID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, n.Connected, connectedness)
 }
 

--- a/deals/module/deals_test.go
+++ b/deals/module/deals_test.go
@@ -55,16 +55,16 @@ func TestStore(t *testing.T) {
 				deals.WithAscending(true),
 				deals.WithFromAddrs(addr.String()),
 			)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Len(t, pending, nm)
 			final, err := m.ListStorageDealRecords(deals.WithIncludeFinal(true))
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Empty(t, final)
 			err = waitForDealComplete(client, pcids)
 			checkErr(t, err)
 			time.Sleep(util.AvgBlockTime)
 			pending, err = m.ListStorageDealRecords(deals.WithIncludePending(true))
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Empty(t, pending)
 			final, err = m.ListStorageDealRecords(
 				deals.WithIncludeFinal(true),
@@ -72,7 +72,7 @@ func TestStore(t *testing.T) {
 				deals.WithAscending(true),
 				deals.WithFromAddrs(addr.String()),
 			)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Len(t, final, nm)
 		})
 	}
@@ -105,7 +105,7 @@ func TestRetrieve(t *testing.T) {
 				t.Fatal("retrieved data doesn't match with stored data")
 			}
 			retrievals, err := m.ListRetrievalDealRecords()
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Len(t, retrievals, 1)
 		})
 	}

--- a/deals/module/store_test.go
+++ b/deals/module/store_test.go
@@ -14,19 +14,19 @@ func TestPutPendingDeal(t *testing.T) {
 	s := newStore(tests.NewTxMapDatastore())
 
 	c1, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = s.putPendingDeal(deals.StorageDealRecord{Addr: "a", Time: time.Now().Unix(), Pending: true, DealInfo: deals.StorageDealInfo{ProposalCid: c1}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	c2, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2E")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = s.putPendingDeal(deals.StorageDealRecord{Addr: "b", Time: time.Now().Unix(), Pending: true, DealInfo: deals.StorageDealInfo{ProposalCid: c2}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	c3, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2F")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = s.putPendingDeal(deals.StorageDealRecord{Addr: "c", Time: time.Now().Unix(), Pending: true, DealInfo: deals.StorageDealInfo{ProposalCid: c3}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestGetPendingDeals(t *testing.T) {
@@ -35,22 +35,22 @@ func TestGetPendingDeals(t *testing.T) {
 	now := time.Now().Unix()
 
 	c1, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = s.putPendingDeal(deals.StorageDealRecord{Addr: "a", Time: now, Pending: true, DealInfo: deals.StorageDealInfo{ProposalCid: c1}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	c2, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2E")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = s.putPendingDeal(deals.StorageDealRecord{Addr: "b", Time: now + 1, Pending: true, DealInfo: deals.StorageDealInfo{ProposalCid: c2}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	c3, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2F")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = s.putPendingDeal(deals.StorageDealRecord{Addr: "c", Time: now + 3, Pending: true, DealInfo: deals.StorageDealInfo{ProposalCid: c3}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	res, err := s.getPendingDeals()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, res, 3)
 }
 
@@ -58,20 +58,20 @@ func TestDeletePendingDeal(t *testing.T) {
 	s := newStore(tests.NewTxMapDatastore())
 
 	c1, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	dr := deals.StorageDealRecord{Addr: "a", Time: time.Now().Unix(), Pending: true, DealInfo: deals.StorageDealInfo{ProposalCid: c1}}
 	err = s.putPendingDeal(dr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	res, err := s.getPendingDeals()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, res, 1)
 
 	err = s.deletePendingDeal(dr.DealInfo.ProposalCid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	res, err = s.getPendingDeals()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Empty(t, res)
 }
 
@@ -79,22 +79,22 @@ func TestPutDealRecord(t *testing.T) {
 	s := newStore(tests.NewTxMapDatastore())
 
 	c1, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	pdr := deals.StorageDealRecord{Addr: "a", Time: time.Now().Unix(), Pending: true, DealInfo: deals.StorageDealInfo{ProposalCid: c1}}
 	err = s.putPendingDeal(pdr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	res, err := s.getPendingDeals()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, res, 1)
 
 	dr := deals.StorageDealRecord{Addr: "a", Time: time.Now().Unix(), Pending: false, DealInfo: deals.StorageDealInfo{ProposalCid: c1}}
 
 	err = s.putFinalDeal(dr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	res, err = s.getPendingDeals()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Empty(t, res)
 }
 
@@ -104,25 +104,25 @@ func TestGetDealRecords(t *testing.T) {
 	now := time.Now().Unix()
 
 	c1, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	dr1 := deals.StorageDealRecord{Addr: "a", Time: now, Pending: false, DealInfo: deals.StorageDealInfo{ProposalCid: c1}}
 	err = s.putFinalDeal(dr1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	c2, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2E")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	dr2 := deals.StorageDealRecord{Addr: "b", Time: now + 1, Pending: false, DealInfo: deals.StorageDealInfo{ProposalCid: c2}}
 	err = s.putFinalDeal(dr2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	c3, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2F")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	dr3 := deals.StorageDealRecord{Addr: "c", Time: now + 2, Pending: false, DealInfo: deals.StorageDealInfo{ProposalCid: c3}}
 	err = s.putFinalDeal(dr3)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	res, err := s.getFinalDeals()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, res, 3)
 }
 
@@ -130,10 +130,10 @@ func TestPutRetrievalRecords(t *testing.T) {
 	s := newStore(tests.NewTxMapDatastore())
 	now := time.Now().Unix()
 	c1, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	rr := deals.RetrievalDealRecord{Time: now, Addr: "from", DealInfo: deals.RetrievalDealInfo{RootCid: c1, Miner: "miner"}}
 	err = s.putRetrieval(rr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestGetRetrievalDeals(t *testing.T) {
@@ -141,22 +141,22 @@ func TestGetRetrievalDeals(t *testing.T) {
 	now := time.Now().Unix()
 
 	c1, err := util.CidFromString("QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	rr := deals.RetrievalDealRecord{Time: now, Addr: "from", DealInfo: deals.RetrievalDealInfo{RootCid: c1, Miner: "miner"}}
 	err = s.putRetrieval(rr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	rr = deals.RetrievalDealRecord{Time: now + 1, Addr: "from", DealInfo: deals.RetrievalDealInfo{RootCid: c1, Miner: "miner"}}
 	err = s.putRetrieval(rr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	rr = deals.RetrievalDealRecord{Time: now + 2, Addr: "from", DealInfo: deals.RetrievalDealInfo{RootCid: c1, Miner: "miner"}}
 	err = s.putRetrieval(rr)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	res, err := s.getRetrievals()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, res, 3)
 }

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -74,7 +74,7 @@ func TestSetDefaultConfig(t *testing.T) {
 		},
 	}
 	err := fapi.SetDefaultConfig(config)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	newConfig := fapi.GetDefaultCidConfig(cid.Undef)
 	require.Equal(t, newConfig.Hot, config.Hot)
 	require.Equal(t, newConfig.Cold, config.Cold)
@@ -97,7 +97,7 @@ func TestNewAddress(t *testing.T) {
 	defer cls()
 
 	addr, err := fapi.NewAddr(context.Background(), "my address")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, addr)
 
 	addrs := fapi.Addrs()
@@ -110,7 +110,7 @@ func TestNewAddressDefault(t *testing.T) {
 	defer cls()
 
 	addr, err := fapi.NewAddr(context.Background(), "my address", api.WithMakeDefault(true))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, addr)
 
 	defaultConf := fapi.DefaultConfig()
@@ -136,7 +136,7 @@ func TestAdd(t *testing.T) {
 
 		cid, _ := addRandomFile(t, r, ipfsAPI)
 		jid, err := fapi.PushConfig(cid)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, nil)
 		requireFilStored(ctx, t, client, cid)
@@ -151,7 +151,7 @@ func TestAdd(t *testing.T) {
 
 		config := fapi.GetDefaultCidConfig(cid).WithHotEnabled(false).WithColdFilDealDuration(int64(1234))
 		jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, &config)
 		requireStorageDealRecord(t, fapi, cid)
@@ -167,15 +167,15 @@ func TestGet(t *testing.T) {
 	r := rand.New(rand.NewSource(22))
 	cid, data := addRandomFile(t, r, ipfs)
 	jid, err := fapi.PushConfig(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, nil)
 
 	t.Run("FromAPI", func(t *testing.T) {
 		r, err := fapi.Get(ctx, cid)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		fetched, err := ioutil.ReadAll(r)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.True(t, bytes.Equal(data, fetched))
 	})
 }
@@ -190,7 +190,7 @@ func TestInfo(t *testing.T) {
 	var first api.InstanceInfo
 	t.Run("Minimal", func(t *testing.T) {
 		first, err = fapi.Info(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, first.ID)
 		require.Len(t, first.Balances, 1)
 		require.NotEmpty(t, first.Balances[0].Addr)
@@ -203,14 +203,14 @@ func TestInfo(t *testing.T) {
 	for i := 0; i < n; i++ {
 		cid, _ := addRandomFile(t, r, ipfs)
 		jid, err := fapi.PushConfig(cid)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, nil)
 	}
 
 	t.Run("WithThreeAdd", func(t *testing.T) {
 		second, err := fapi.Info(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, second.ID, first.ID)
 		require.Len(t, second.Balances, 1)
 		require.Equal(t, second.Balances[0].Addr, first.Balances[0].Addr)
@@ -236,17 +236,17 @@ func TestShow(t *testing.T) {
 		r := rand.New(rand.NewSource(22))
 		cid, _ := addRandomFile(t, r, ipfs)
 		jid, err := fapi.PushConfig(cid)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, nil)
 
 		inf, err := fapi.Info(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(inf.Pins))
 
 		c := inf.Pins[0]
 		s, err := fapi.Show(c)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.True(t, s.Cid.Defined())
 		require.True(t, time.Now().After(s.Created))
@@ -282,14 +282,14 @@ func TestColdInstanceLoad(t *testing.T) {
 	ra := rand.New(rand.NewSource(22))
 	cid, data := addRandomFile(t, ra, ipfs)
 	jid, err := fapi.PushConfig(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, nil)
 
 	info, err := fapi.Info(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	shw, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Now close the FFS Instance, and the manager.
 	err = fapi.Close()
@@ -303,17 +303,17 @@ func TestColdInstanceLoad(t *testing.T) {
 	require.NoError(t, err)
 
 	ninfo, err := fapi.Info(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, info, ninfo)
 
 	nshw, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, shw, nshw)
 
 	r, err := fapi.Get(ctx, cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fetched, err := ioutil.ReadAll(r)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, bytes.Equal(data, fetched))
 }
 
@@ -328,12 +328,12 @@ func TestRepFactor(t *testing.T) {
 			cid, _ := addRandomFile(t, r, ipfsAPI)
 			config := fapi.GetDefaultCidConfig(cid).WithColdFilRepFactor(rf)
 			jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-			require.Nil(t, err)
+			require.NoError(t, err)
 			requireJobState(t, fapi, jid, ffs.Success)
 			requireCidConfig(t, fapi, cid, &config)
 
 			cinfo, err := fapi.Show(cid)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, rf, len(cinfo.Cold.Filecoin.Proposals))
 		})
 	}
@@ -346,22 +346,22 @@ func TestRepFactorIncrease(t *testing.T) {
 	defer cls()
 	cid, _ := addRandomFile(t, r, ipfsAPI)
 	jid, err := fapi.PushConfig(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, nil)
 
 	cinfo, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(cinfo.Cold.Filecoin.Proposals))
 	firstProposal := cinfo.Cold.Filecoin.Proposals[0]
 
 	config := fapi.GetDefaultCidConfig(cid).WithColdFilRepFactor(2)
 	jid, err = fapi.PushConfig(cid, api.WithCidConfig(config), api.WithOverride(true))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 	cinfo, err = fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 2, len(cinfo.Cold.Filecoin.Proposals))
 	require.Contains(t, cinfo.Cold.Filecoin.Proposals, firstProposal)
 }
@@ -375,22 +375,22 @@ func TestRepFactorDecrease(t *testing.T) {
 	cid, _ := addRandomFile(t, r, ipfsAPI)
 	config := fapi.GetDefaultCidConfig(cid).WithColdFilRepFactor(2)
 	jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 
 	cinfo, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 2, len(cinfo.Cold.Filecoin.Proposals))
 
 	config = fapi.GetDefaultCidConfig(cid).WithColdFilRepFactor(1)
 	jid, err = fapi.PushConfig(cid, api.WithCidConfig(config), api.WithOverride(true))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 
 	cinfo, err = fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 2, len(cinfo.Cold.Filecoin.Proposals))
 }
 
@@ -403,7 +403,7 @@ func TestHotTimeoutConfig(t *testing.T) {
 		cid, _ := util.CidFromString("Qmc5gCcjYypU7y28oCALwfSvxCBskLuPKWpK4qpterKC7z")
 		config := fapi.GetDefaultCidConfig(cid).WithHotIpfsAddTimeout(1)
 		jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Failed)
 	})
 }
@@ -418,11 +418,11 @@ func TestDurationConfig(t *testing.T) {
 	duration := int64(1234)
 	config := fapi.GetDefaultCidConfig(cid).WithColdFilDealDuration(duration)
 	jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 	cinfo, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	p := cinfo.Cold.Filecoin.Proposals[0]
 	require.Greater(t, p.Duration, duration)
 	require.Greater(t, p.ActivationEpoch, int64(0))
@@ -439,11 +439,11 @@ func TestFilecoinExcludedMiners(t *testing.T) {
 	config := fapi.GetDefaultCidConfig(cid).WithColdFilExcludedMiners([]string{excludedMiner})
 
 	jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 	cinfo, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	p := cinfo.Cold.Filecoin.Proposals[0]
 	require.NotEqual(t, p.Miner, excludedMiner)
 }
@@ -459,11 +459,11 @@ func TestFilecoinTrustedMiner(t *testing.T) {
 	config := fapi.GetDefaultCidConfig(cid).WithColdFilTrustedMiners([]string{trustedMiner})
 
 	jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 	cinfo, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	p := cinfo.Cold.Filecoin.Proposals[0]
 	require.Equal(t, p.Miner, trustedMiner)
 }
@@ -498,11 +498,11 @@ func TestFilecoinCountryFilter(t *testing.T) {
 	config := fapi.GetDefaultCidConfig(cid).WithColdFilCountryCodes(countryFilter)
 
 	jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 	cinfo, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	p := cinfo.Cold.Filecoin.Proposals[0]
 	require.Equal(t, p.Miner, "t01001")
 }
@@ -527,16 +527,16 @@ func TestFilecoinMaxPriceFilter(t *testing.T) {
 
 	config := fapi.GetDefaultCidConfig(cid).WithColdMaxPrice(400000000)
 	jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Failed)
 
 	config = fapi.GetDefaultCidConfig(cid).WithColdMaxPrice(600000000)
 	jid, err = fapi.PushConfig(cid, api.WithCidConfig(config), api.WithOverride(true))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 	cinfo, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	p := cinfo.Cold.Filecoin.Proposals[0]
 	require.Equal(t, p.Miner, "t01000")
 }
@@ -564,7 +564,7 @@ func TestFilecoinEnableConfig(t *testing.T) {
 			config := fapi.GetDefaultCidConfig(cid).WithColdEnabled(tt.ColdEnabled).WithHotEnabled(tt.HotEnabled)
 
 			jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			expectedJobState := ffs.Success
 			requireJobState(t, fapi, jid, expectedJobState)
@@ -574,7 +574,7 @@ func TestFilecoinEnableConfig(t *testing.T) {
 
 				// Show() assertions
 				cinfo, err := fapi.Show(cid)
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.Equal(t, tt.HotEnabled, cinfo.Hot.Enabled)
 				if tt.ColdEnabled {
 					require.NotEmpty(t, cinfo.Cold.Filecoin.Proposals)
@@ -636,14 +636,14 @@ func TestEnabledConfigChange(t *testing.T) {
 		config := fapi.GetDefaultCidConfig(cid)
 
 		jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, &config)
 		requireIpfsPinnedCid(ctx, t, cid, ipfsAPI)
 
 		config = fapi.GetDefaultCidConfig(cid).WithHotEnabled(false)
 		jid, err = fapi.PushConfig(cid, api.WithCidConfig(config), api.WithOverride(true))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, &config)
 		requireIpfsUnpinnedCid(ctx, t, cid, ipfsAPI)
@@ -658,14 +658,14 @@ func TestEnabledConfigChange(t *testing.T) {
 		config := fapi.GetDefaultCidConfig(cid).WithHotEnabled(false)
 
 		jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, &config)
 		requireIpfsUnpinnedCid(ctx, t, cid, ipfsAPI)
 
 		config = fapi.GetDefaultCidConfig(cid).WithHotEnabled(true)
 		jid, err = fapi.PushConfig(cid, api.WithCidConfig(config), api.WithOverride(true))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, &config)
 		requireIpfsPinnedCid(ctx, t, cid, ipfsAPI)
@@ -680,14 +680,14 @@ func TestEnabledConfigChange(t *testing.T) {
 		config := fapi.GetDefaultCidConfig(cid).WithColdEnabled(false)
 
 		jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, &config)
 		requireFilUnstored(ctx, t, client, cid)
 
 		config = fapi.GetDefaultCidConfig(cid).WithHotEnabled(true)
 		jid, err = fapi.PushConfig(cid, api.WithCidConfig(config), api.WithOverride(true))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, &config)
 		requireFilStored(ctx, t, client, cid)
@@ -702,14 +702,14 @@ func TestEnabledConfigChange(t *testing.T) {
 		config := fapi.GetDefaultCidConfig(cid).WithColdEnabled(false)
 
 		jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, cid, &config)
 		requireFilUnstored(ctx, t, client, cid)
 
 		config = fapi.GetDefaultCidConfig(cid).WithHotEnabled(true)
 		jid, err = fapi.PushConfig(cid, api.WithCidConfig(config), api.WithOverride(true))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 
 		// Yes, still stored in filecoin since deals can't be
@@ -746,7 +746,7 @@ func TestUnfreeze(t *testing.T) {
 
 	config := fapi.GetDefaultCidConfig(cid).WithHotEnabled(false).WithHotAllowUnfreeze(true)
 	jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 
@@ -754,17 +754,17 @@ func TestUnfreeze(t *testing.T) {
 	require.Equal(t, api.ErrHotStorageDisabled, err)
 
 	err = ipfsAPI.Dag().Remove(ctx, cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	config = config.WithHotEnabled(true)
 	jid, err = fapi.PushConfig(cid, api.WithCidConfig(config), api.WithOverride(true))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 
 	r, err := fapi.Get(ctx, cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	fetched, err := ioutil.ReadAll(r)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, bytes.Equal(data, fetched))
 	requireRetrievalDealRecord(t, fapi, cid)
 }
@@ -780,12 +780,12 @@ func TestRenew(t *testing.T) {
 	renewThreshold := 12600
 	config := fapi.GetDefaultCidConfig(cid).WithColdFilDealDuration(int64(100)).WithColdFilRenew(true, renewThreshold)
 	jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 
 	i, err := fapi.Show(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(i.Cold.Filecoin.Proposals))
 
 	ticker := time.NewTicker(time.Second)
@@ -794,10 +794,10 @@ func TestRenew(t *testing.T) {
 Loop:
 	for range ticker.C {
 		i, err := fapi.Show(cid)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		firstDeal := i.Cold.Filecoin.Proposals[0]
-		require.Nil(t, err)
+		require.NoError(t, err)
 		if len(i.Cold.Filecoin.Proposals) < 2 {
 			require.Greater(t, epochDeadline, 0)
 			continue
@@ -827,7 +827,7 @@ func TestRenewWithDecreasedRepFactor(t *testing.T) {
 	renewThreshold := 12600
 	config := fapi.GetDefaultCidConfig(cid).WithColdFilDealDuration(int64(100)).WithColdFilRenew(true, renewThreshold).WithColdFilRepFactor(2)
 	jid, err := fapi.PushConfig(cid, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 
@@ -835,7 +835,7 @@ func TestRenewWithDecreasedRepFactor(t *testing.T) {
 	// Both now active deals shouldn't be renewed, only one of them.
 	config = config.WithColdFilRepFactor(1)
 	jid, err = fapi.PushConfig(cid, api.WithCidConfig(config), api.WithOverride(true))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, cid, &config)
 
@@ -845,11 +845,11 @@ func TestRenewWithDecreasedRepFactor(t *testing.T) {
 Loop:
 	for range ticker.C {
 		i, err := fapi.Show(cid)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		firstDeal := i.Cold.Filecoin.Proposals[0]
 		secondDeal := i.Cold.Filecoin.Proposals[1]
-		require.Nil(t, err)
+		require.NoError(t, err)
 		if len(i.Cold.Filecoin.Proposals) < 3 {
 			epochDeadline--
 			require.Greater(t, epochDeadline, 0)
@@ -995,13 +995,13 @@ func TestPushCidReplace(t *testing.T) {
 	// Test tipical case
 	config := fapi.GetDefaultCidConfig(c1).WithColdEnabled(false)
 	jid, err := fapi.PushConfig(c1, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, c1, &config)
 
 	c2, _ := addRandomFile(t, r, ipfs)
 	jid, err = fapi.Replace(c1, c2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 
 	config2, err := fapi.GetCidConfig(c2)
@@ -1038,13 +1038,13 @@ func TestDoubleReplace(t *testing.T) {
 		c1, _ := addRandomFile(t, r, ipfs)
 		config := fapi.GetDefaultCidConfig(c1).WithColdEnabled(false)
 		jid, err := fapi.PushConfig(c1, api.WithCidConfig(config))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 		requireCidConfig(t, fapi, c1, &config)
 
 		c2, _ := addRandomFile(t, r, ipfs)
 		jid, err = fapi.Replace(c1, c2)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		requireJobState(t, fapi, jid, ffs.Success)
 	}
 
@@ -1064,7 +1064,7 @@ func TestRemove(t *testing.T) {
 
 	config := fapi.GetDefaultCidConfig(c1).WithColdEnabled(false)
 	jid, err := fapi.PushConfig(c1, api.WithCidConfig(config))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Success)
 	requireCidConfig(t, fapi, c1, &config)
 
@@ -1074,10 +1074,10 @@ func TestRemove(t *testing.T) {
 	config = config.WithHotEnabled(false)
 	jid, err = fapi.PushConfig(c1, api.WithCidConfig(config), api.WithOverride(true))
 	requireJobState(t, fapi, jid, ffs.Success)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = fapi.Remove(c1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = fapi.GetCidConfig(c1)
 	require.Equal(t, api.ErrNotFound, err)
 }
@@ -1109,24 +1109,24 @@ func TestSendFil(t *testing.T) {
 	addr1 := addrs[0].Addr
 
 	addr2, err := fapi.NewAddr(ctx, "addr2")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	hasInitialBal := func() bool {
 		bal, err := balForAddress(addr2)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		return bal == uint64(iWalletBal)
 	}
 
 	hasNewBal := func() bool {
 		bal, err := balForAddress(addr2)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		return bal == uint64(iWalletBal+amt)
 	}
 
 	require.Eventually(t, hasInitialBal, time.Second*5, time.Second)
 
 	err = fapi.SendFil(ctx, addr1, addr2, big.NewInt(amt))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Eventually(t, hasNewBal, time.Second*5, time.Second)
 }
@@ -1202,7 +1202,7 @@ func TestFailedJobMessage(t *testing.T) {
 	c1, _ := addRandomFileSize(t, r, ipfs, 2000)
 
 	jid, err := fapi.PushConfig(c1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	job := requireJobState(t, fapi, jid, ffs.Failed)
 	require.NotEmpty(t, job.ErrCause)
 	require.Len(t, job.DealErrors, 1)
@@ -1220,7 +1220,7 @@ func TestLogHistory(t *testing.T) {
 	r := rand.New(rand.NewSource(22))
 	c, _ := addRandomFile(t, r, ipfs)
 	jid, err := fapi.PushConfig(c)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	job := requireJobState(t, fapi, jid, ffs.Success)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
@@ -1261,7 +1261,7 @@ func TestResumeScheduler(t *testing.T) {
 	r := rand.New(rand.NewSource(22))
 	c, _ := addRandomFile(t, r, ipfs)
 	jid, err := fapi.PushConfig(c)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	time.Sleep(time.Second * 3)
 	ds2, err := ds.Clone()
@@ -1291,7 +1291,7 @@ func TestParallelExecution(t *testing.T) {
 	for i := 0; i < n; i++ {
 		cid, _ := addRandomFile(t, r, ipfs)
 		jid, err := fapi.PushConfig(cid)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		cids[i] = cid
 		jids[i] = jid
 		// Add some sleep time to avoid all of them
@@ -1318,7 +1318,7 @@ func TestJobCancellation(t *testing.T) {
 
 	cid, _ := addRandomFile(t, r, ipfsAPI)
 	jid, err := fapi.PushConfig(cid)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	requireJobState(t, fapi, jid, ffs.Executing)
 	time.Sleep(time.Second * 2)
 
@@ -1378,7 +1378,7 @@ func newDevnet(t *testing.T, numMiners int, ipfsAddr string) (address.Address, *
 
 func newFFSManager(t *testing.T, ds datastore.TxnDatastore, lotusClient *apistruct.FullNodeStruct, masterAddr address.Address, ms ffs.MinerSelector, ipfsClient *httpapi.HttpApi) (*manager.Manager, func()) {
 	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), lotusClient)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	fchain := filchain.New(lotusClient)
 	l := cidlogger.New(txndstr.Wrap(ds, "ffs/cidlogger"))
@@ -1389,7 +1389,7 @@ func newFFSManager(t *testing.T, ds datastore.TxnDatastore, lotusClient *apistru
 	require.NoError(t, err)
 
 	wm, err := walletModule.New(lotusClient, masterAddr, *big.NewInt(iWalletBal), false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	pm := paych.New(lotusClient)
 
@@ -1475,14 +1475,14 @@ func requireCidConfig(t *testing.T, fapi *api.API, c cid.Cid, config *ffs.CidCon
 func requireStorageDealRecord(t *testing.T, fapi *api.API, c cid.Cid) {
 	time.Sleep(time.Second)
 	recs, err := fapi.ListStorageDealRecords(deals.WithIncludeFinal(true))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	require.Equal(t, c, recs[0].RootCid)
 }
 
 func requireRetrievalDealRecord(t *testing.T, fapi *api.API, c cid.Cid) {
 	recs, err := fapi.ListRetrievalDealRecords()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, recs, 1)
 	require.Equal(t, c, recs[0].DealInfo.RootCid)
 }

--- a/ffs/manager/manager_test.go
+++ b/ffs/manager/manager_test.go
@@ -36,7 +36,7 @@ func TestCreate(t *testing.T) {
 	defer cls()
 
 	id, auth, err := m.Create(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotEmpty(t, auth)
 	require.True(t, id.Valid())
 }
@@ -49,21 +49,21 @@ func TestList(t *testing.T) {
 	defer cls()
 
 	lst, err := m.List()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(lst))
 
 	id1, _, err := m.Create(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	lst, err = m.List()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(lst))
 	require.Contains(t, lst, id1)
 
 	id2, _, err := m.Create(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	lst, err = m.List()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Contains(t, lst, id1)
 	require.Contains(t, lst, id2)
 	require.Equal(t, 2, len(lst))
@@ -76,11 +76,11 @@ func TestGetByAuthToken(t *testing.T) {
 	m, cls := newManager(t, ds)
 	defer cls()
 	id, auth, err := m.Create(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	t.Run("Hot", func(t *testing.T) {
 		new, err := m.GetByAuthToken(auth)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, id, new.ID())
 		require.NotEmpty(t, new.Addrs())
 	})
@@ -88,7 +88,7 @@ func TestGetByAuthToken(t *testing.T) {
 		m, cls := newManager(t, ds)
 		defer cls()
 		new, err := m.GetByAuthToken(auth)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, id, new.ID())
 		require.NotEmpty(t, new.Addrs())
 	})
@@ -131,12 +131,12 @@ func TestDefaultConfig(t *testing.T) {
 func newManager(t *testing.T, ds datastore.TxnDatastore) (*Manager, func()) {
 	client, addr, _ := tests.CreateLocalDevnet(t, 1)
 	wm, err := walletModule.New(client, addr, *big.NewInt(4000000000), false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	pm := paych.New(client)
 	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), client)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	m, err := New(ds, wm, pm, dm, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	cls := func() {
 		require.Nil(t, m.Close())
 	}

--- a/ffs/scheduler/internal/jstore/jstore_test.go
+++ b/ffs/scheduler/internal/jstore/jstore_test.go
@@ -16,9 +16,9 @@ func TestEnqueue(t *testing.T) {
 	s := create(t)
 	j := createJob()
 	err := s.Enqueue(j)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	jQueued, err := s.Get(j.ID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	j.Status = ffs.Queued
 	require.Equal(t, j, jQueued)
 }
@@ -30,9 +30,9 @@ func TestDequeue(t *testing.T) {
 		s := create(t)
 		j := createJob()
 		err := s.Enqueue(j)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		j2, err := s.Dequeue()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		j.Status = ffs.Executing
 		require.NotNil(t, j2)
 		require.Equal(t, j, *j2)
@@ -41,7 +41,7 @@ func TestDequeue(t *testing.T) {
 		t.Parallel()
 		s := create(t)
 		j, err := s.Dequeue()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Nil(t, j)
 	})
 	t.Run("ExecutingAndFinalized", func(t *testing.T) {
@@ -50,28 +50,28 @@ func TestDequeue(t *testing.T) {
 
 		j1 := createJob()
 		err := s.Enqueue(j1)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		_, err = s.Dequeue()
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		j2 := createJob()
 		err = s.Enqueue(j2)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		// Dequeue should be nil since j1 is Executing,
 		// and j2 can't be returned until that fininishes since
 		// both are jobs for the same Cid.
 		jq, err := s.Dequeue()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Nil(t, jq)
 
 		errors := []ffs.DealError{{ProposalCid: cid.Undef, Miner: "t0100", Message: "abcd"}}
 		err = s.Finalize(j1.ID, ffs.Success, nil, errors)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		// Dequeue now returns a new job since the Executing one
 		// was finalized
 		jq, err = s.Dequeue()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, jq)
 		j2.Status = ffs.Executing
 		require.Equal(t, j2, *jq)
@@ -84,18 +84,18 @@ func TestCancelation(t *testing.T) {
 
 	j1 := createJob()
 	err := s.Enqueue(j1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	j2 := createJob()
 	err = s.Enqueue(j2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	j1Canceled, err := s.Get(j1.ID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, ffs.Canceled, j1Canceled.Status)
 
 	j2Queued, err := s.Get(j2.ID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, ffs.Queued, j2Queued.Status)
 }
 

--- a/health/module_test.go
+++ b/health/module_test.go
@@ -21,7 +21,7 @@ func TestModule(t *testing.T) {
 
 	t.Run("Health", func(t *testing.T) {
 		status, messages, err := m.Check(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, Ok, status)
 		require.Empty(t, messages)
 	})

--- a/net/lotus/module_test.go
+++ b/net/lotus/module_test.go
@@ -20,50 +20,50 @@ func TestModule(t *testing.T) {
 
 	t.Run("ListenAddr", func(t *testing.T) {
 		addrInfo, err := m.ListenAddr(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, addrInfo.ID.String())
 		require.NotEmpty(t, addrInfo.Addrs)
 	})
 
 	t.Run("Peers", func(t *testing.T) {
 		peers, err := m.Peers(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, peers)
 	})
 
 	t.Run("Connectedness", func(t *testing.T) {
 		peers, err := m.Peers(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, peers)
 		c, err := m.Connectedness(ctx, peers[0].AddrInfo.ID)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, net.Connected, c)
 	})
 
 	t.Run("FindPeer", func(t *testing.T) {
 		peers, err := m.Peers(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, peers)
 		peer, err := m.FindPeer(ctx, peers[0].AddrInfo.ID)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, peers[0].AddrInfo.ID, peer.AddrInfo.ID)
 	})
 
 	t.Run("DisconnectAndConnect", func(t *testing.T) {
 		peers0, err := m.Peers(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEmpty(t, peers0)
 
 		err = m.DisconnectPeer(ctx, peers0[0].AddrInfo.ID)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		peers1, err := m.Peers(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Empty(t, peers1)
 
 		err = m.ConnectPeer(ctx, peers0[0].AddrInfo)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		peers2, err := m.Peers(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Len(t, peers2, 1)
 	})
 }

--- a/paych/lotus/module_test.go
+++ b/paych/lotus/module_test.go
@@ -18,7 +18,7 @@ func TestModule(t *testing.T) {
 
 	t.Run("List", func(t *testing.T) {
 		paychInfos, err := m.List(ctx)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Empty(t, paychInfos)
 	})
 

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -11,7 +11,7 @@ const cidString = "QmSqL792vF4fGjStbYHRgazsEahAQKZmx68jrnvFi9hXMp"
 
 func TestCidToString(t *testing.T) {
 	c, err := cid.Decode(cidString)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	s := CidToString(c)
 	require.Equal(t, cidString, s)
 	c = cid.Undef
@@ -21,16 +21,16 @@ func TestCidToString(t *testing.T) {
 
 func TestCidFromString(t *testing.T) {
 	orig, err := cid.Decode(cidString)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	c, err := CidFromString(cidString)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, orig, c)
 	c, err = CidFromString(CidUndef)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, cid.Undef, c)
 	c, err = CidFromString(DefaultCidUndef)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, cid.Undef, c)
 	_, err = CidFromString("xyz")
-	require.NotNil(t, err)
+	require.Error(t, err)
 }


### PR DESCRIPTION
replaces calls to require/assert Nil/NotNil to NoError/Error

[NoError](https://godoc.org/github.com/stretchr/testify/require#NoError) is for asserting no error was return
[Error](https://godoc.org/github.com/stretchr/testify/require#Error) is for asserting an error was returned

## Why is it important?

```golang
return Fail(t, fmt.Sprintf("Received unexpected error:\n%+v", err), msgAndArgs...)
```
```golang
return Fail(t, "An error is expected but got nil.", msgAndArgs...)
```
When these fail their message explicitly calls out that we were or were not expecting an error. This communicates the intent of the assertion.