### PR TITLE
support different network faucets

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -136,9 +136,10 @@ func NewServer(conf Config) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting Lotus network name: %s", err)
 	}
-	log.Infof("Detected Lotus node connected to network: %s", network)
+	networkName := string(network)
+	log.Infof("Detected Lotus node connected to network: %s", networkName)
 
-	fchost, err := fchost.New(string(network), !conf.Devnet)
+	fchost, err := fchost.New(networkName, !conf.Devnet)
 	if err != nil {
 		return nil, fmt.Errorf("creating filecoin host: %s", err)
 	}
@@ -181,7 +182,7 @@ func NewServer(conf Config) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating deal module: %s", err)
 	}
-	wm, err := walletModule.New(c, masterAddr, conf.WalletInitialFunds, conf.AutocreateMasterAddr)
+	wm, err := walletModule.New(c, masterAddr, conf.WalletInitialFunds, conf.AutocreateMasterAddr, networkName)
 	if err != nil {
 		return nil, fmt.Errorf("creating wallet module: %s", err)
 	}

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1388,7 +1388,7 @@ func newFFSManager(t *testing.T, ds datastore.TxnDatastore, lotusClient *apistru
 	sched, err := scheduler.New(txndstr.Wrap(ds, "ffs/scheduler"), l, hl, cl)
 	require.NoError(t, err)
 
-	wm, err := walletModule.New(lotusClient, masterAddr, *big.NewInt(iWalletBal), false)
+	wm, err := walletModule.New(lotusClient, masterAddr, *big.NewInt(iWalletBal), false, "")
 	require.NoError(t, err)
 
 	pm := paych.New(lotusClient)

--- a/ffs/manager/manager_test.go
+++ b/ffs/manager/manager_test.go
@@ -130,7 +130,7 @@ func TestDefaultStorageConfig(t *testing.T) {
 
 func newManager(t *testing.T, ds datastore.TxnDatastore) (*Manager, func()) {
 	client, addr, _ := tests.CreateLocalDevnet(t, 1)
-	wm, err := walletModule.New(client, addr, *big.NewInt(4000000000), false)
+	wm, err := walletModule.New(client, addr, *big.NewInt(4000000000), false, "")
 	require.NoError(t, err)
 	pm := paych.New(client)
 	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), client)

--- a/go.mod
+++ b/go.mod
@@ -55,3 +55,5 @@ require (
 	google.golang.org/grpc v1.30.0
 	google.golang.org/protobuf v1.25.0
 )
+
+replace github.com/dgraph-io/badger/v2 => github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200718033852-37ee16d8ad1c

--- a/go.sum
+++ b/go.sum
@@ -195,12 +195,12 @@ github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Ev
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.1 h1:w9pSFNSdq/JPM1N12Fz/F/bzo993Is1W+Q7HjPzi7yg=
 github.com/dgraph-io/badger v1.6.1/go.mod h1:FRmFw3uxvcpa8zG3Rxs0th+hCLIuaQg8HlNV5bjgnuU=
-github.com/dgraph-io/badger/v2 v2.0.3 h1:inzdf6VF/NZ+tJ8RwwYMjJMvsOALTHYdozn0qSl6XJI=
-github.com/dgraph-io/badger/v2 v2.0.3/go.mod h1:3KY8+bsP8wI0OEnQJAKpd4wIJW/Mm32yw2j/9FUVnIM=
-github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3 h1:MQLRM35Pp0yAyBYksjbj1nZI/w6eyRY/mWoM1sFf4kU=
-github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200718033852-37ee16d8ad1c h1:LoEZfU53r3H1et4WY9M0h1c3fuCljBnn3pk/7TB5eWY=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200718033852-37ee16d8ad1c/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=

--- a/wallet/module/wallet.go
+++ b/wallet/module/wallet.go
@@ -149,7 +149,7 @@ func (m *Module) SendFil(ctx context.Context, from string, to string, amount *bi
 func (m *Module) FundFromFaucet(ctx context.Context, addr string) error {
 	faucet, ok := networkFaucet[m.networkName]
 	if !ok {
-		return fmt.Errorf("unkown network faucet for network %s", m.networkName)
+		return fmt.Errorf("unkown faucet for network %s", m.networkName)
 	}
 
 	req, err := http.NewRequest("GET", faucet+"/send", nil)

--- a/wallet/module/wallet.go
+++ b/wallet/module/wallet.go
@@ -149,7 +149,7 @@ func (m *Module) SendFil(ctx context.Context, from string, to string, amount *bi
 func (m *Module) FundFromFaucet(ctx context.Context, addr string) error {
 	faucet, ok := networkFaucet[m.networkName]
 	if !ok {
-		return fmt.Errorf("unkown faucet for network %s", m.networkName)
+		return fmt.Errorf("unknown faucet for network %s", m.networkName)
 	}
 
 	req, err := http.NewRequest("GET", faucet+"/send", nil)

--- a/wallet/module/wallet.go
+++ b/wallet/module/wallet.go
@@ -18,21 +18,28 @@ import (
 
 var (
 	log = logger.Logger("wallet")
+
+	networkFaucet = map[string]string{
+		"testnet":  "https://faucet.testnet.filecoin.io",
+		"nerpanet": "https://faucet.nerpa.fildev.network",
+	}
 )
 
 // Module exposes the filecoin wallet api.
 type Module struct {
-	api        *apistruct.FullNodeStruct
-	iAmount    *big.Int
-	masterAddr address.Address
+	api         *apistruct.FullNodeStruct
+	iAmount     *big.Int
+	masterAddr  address.Address
+	networkName string
 }
 
 // New creates a new wallet module.
-func New(api *apistruct.FullNodeStruct, maddr address.Address, iam big.Int, autocreate bool) (*Module, error) {
+func New(api *apistruct.FullNodeStruct, maddr address.Address, iam big.Int, autocreate bool, networkName string) (*Module, error) {
 	m := &Module{
-		api:        api,
-		iAmount:    &iam,
-		masterAddr: maddr,
+		api:         api,
+		iAmount:     &iam,
+		masterAddr:  maddr,
+		networkName: networkName,
 	}
 	if maddr == address.Undef && autocreate {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
@@ -140,7 +147,12 @@ func (m *Module) SendFil(ctx context.Context, from string, to string, amount *bi
 
 // FundFromFaucet make a faucet call to fund the provided wallet address.
 func (m *Module) FundFromFaucet(ctx context.Context, addr string) error {
-	req, err := http.NewRequest("GET", "https://faucet.testnet.filecoin.io/send", nil)
+	faucet, ok := networkFaucet[m.networkName]
+	if !ok {
+		return fmt.Errorf("unkown network faucet for network %s", m.networkName)
+	}
+
+	req, err := http.NewRequest("GET", faucet+"/send", nil)
 	if err != nil {
 		return fmt.Errorf("parsing fountain url: %s", err)
 	}


### PR DESCRIPTION
This PR addes support for multiple faucets depending the network Powergate is being connected to.
This is needed to correct support of master address auto-creation and funding.