### PR TITLE
Make client take a string target

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -62,14 +62,15 @@ func NewClient(target string, optsOverrides ...grpc.DialOption) (*Client, error)
 		creds = credentials.NewTLS(&tls.Config{})
 	}
 
+	auth := TokenAuth{}
 	var opts []grpc.DialOption
 	if creds != nil {
 		opts = append(opts, grpc.WithTransportCredentials(creds))
+		auth.secure = true
 	} else {
 		opts = append(opts, grpc.WithInsecure())
 	}
 
-	auth := TokenAuth{}
 	opts = append(opts, grpc.WithPerRPCCredentials(auth))
 	opts = append(opts, optsOverrides...)
 

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"strings"
 
-	"github.com/multiformats/go-multiaddr"
 	ffsRpc "github.com/textileio/powergate/ffs/rpc"
 	healthRpc "github.com/textileio/powergate/health/rpc"
 	askRpc "github.com/textileio/powergate/index/ask/rpc"
@@ -13,7 +12,6 @@ import (
 	minerRpc "github.com/textileio/powergate/index/miner/rpc"
 	netRpc "github.com/textileio/powergate/net/rpc"
 	reputationRpc "github.com/textileio/powergate/reputation/rpc"
-	"github.com/textileio/powergate/util"
 	walletRpc "github.com/textileio/powergate/wallet/rpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -58,14 +56,9 @@ func (t TokenAuth) RequireTransportSecurity() bool {
 }
 
 // NewClient creates a client.
-func NewClient(ma multiaddr.Multiaddr, optsOverrides ...grpc.DialOption) (*Client, error) {
-	addr, err := util.TCPAddrFromMultiAddr(ma)
-	if err != nil {
-		return nil, err
-	}
-
+func NewClient(target string, optsOverrides ...grpc.DialOption) (*Client, error) {
 	var creds credentials.TransportCredentials
-	if strings.Contains(addr, "443") {
+	if strings.Contains(target, "443") {
 		creds = credentials.NewTLS(&tls.Config{})
 	}
 
@@ -80,7 +73,7 @@ func NewClient(ma multiaddr.Multiaddr, optsOverrides ...grpc.DialOption) (*Clien
 	opts = append(opts, grpc.WithPerRPCCredentials(auth))
 	opts = append(opts, optsOverrides...)
 
-	conn, err := grpc.Dial(addr, opts...)
+	conn, err := grpc.Dial(target, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -2,8 +2,6 @@ package client
 
 import (
 	"testing"
-
-	"github.com/multiformats/go-multiaddr"
 )
 
 func TestClient(t *testing.T) {
@@ -11,11 +9,7 @@ func TestClient(t *testing.T) {
 	done := setupServer(t)
 	defer done()
 
-	ma, err := multiaddr.NewMultiaddr(grpcHostAddress)
-	if err != nil {
-		t.Fatalf("parsing multiaddress: %s", err)
-	}
-	client, err := NewClient(ma)
+	client, err := NewClient(grpcHostAddress)
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}

--- a/api/client/utils_test.go
+++ b/api/client/utils_test.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	grpcHostNetwork     = "tcp"
-	grpcHostAddress     = "/ip4/127.0.0.1/tcp/5002"
+	grpcHostAddress     = "127.0.0.1:5002"
 	grpcWebProxyAddress = "127.0.0.1:6002"
 	gatewayHostAddr     = "0.0.0.0:7000"
 	ctx                 = context.Background()

--- a/api/client/utils_test.go
+++ b/api/client/utils_test.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	grpcHostNetwork     = "tcp"
-	grpcHostAddress     = "127.0.0.1:5002"
+	grpcHostAddress     = "/ip4/127.0.0.1/tcp/5002"
 	grpcWebProxyAddress = "127.0.0.1:6002"
 	gatewayHostAddr     = "0.0.0.0:7000"
 	ctx                 = context.Background()

--- a/cmd/pow/cmd/root.go
+++ b/cmd/pow/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/multiformats/go-multiaddr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	client "github.com/textileio/powergate/api/client"
@@ -27,9 +26,7 @@ var (
 
 			target := viper.GetString("serverAddress")
 
-			ma, err := multiaddr.NewMultiaddr(target)
-			checkErr(err)
-			fcClient, err = client.NewClient(ma)
+			fcClient, err = client.NewClient(target)
 			checkErr(err)
 		},
 	}

--- a/cmd/powbench/main.go
+++ b/cmd/powbench/main.go
@@ -8,7 +8,6 @@ import (
 	"syscall"
 
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/textileio/powergate/cmd/powbench/runner"
@@ -43,13 +42,10 @@ func main() {
 		log.Fatalf("binding flags: %s", err)
 	}
 
-	lma, err := multiaddr.NewMultiaddr(config.GetString(cmdPowergateAddr))
-	if err != nil {
-		log.Fatalf("parsing lotus multiaddr: %s", err)
-	}
+	pgAddr := config.GetString(cmdPowergateAddr)
 	ts := runner.TestSetup{
-		LotusAddr: lma,
-		MinerAddr: config.GetString(cmdMinerAddr),
+		PowergateAddr: pgAddr,
+		MinerAddr:     config.GetString(cmdMinerAddr),
 
 		SampleSize:   config.GetInt64(cmdSampleSize),
 		MaxParallel:  config.GetInt(cmdMaxParallel),

--- a/cmd/powbench/runner/runner.go
+++ b/cmd/powbench/runner/runner.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/textileio/powergate/api/client"
 	"github.com/textileio/powergate/ffs"
 	"github.com/textileio/powergate/health"
@@ -20,17 +19,17 @@ var (
 
 // TestSetup describes a test configuration.
 type TestSetup struct {
-	LotusAddr    multiaddr.Multiaddr
-	MinerAddr    string
-	SampleSize   int64
-	MaxParallel  int
-	TotalSamples int
-	RandSeed     int
+	PowergateAddr string
+	MinerAddr     string
+	SampleSize    int64
+	MaxParallel   int
+	TotalSamples  int
+	RandSeed      int
 }
 
 // Run runs a test setup.
 func Run(ctx context.Context, ts TestSetup) error {
-	c, err := client.NewClient(ts.LotusAddr)
+	c, err := client.NewClient(ts.PowergateAddr)
 	defer func() {
 		if err := c.Close(); err != nil {
 			log.Errorf("closing powergate client: %s", err)

--- a/cmd/powbench/runner/runner_test.go
+++ b/cmd/powbench/runner/runner_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	lotusAddr = "127.0.0.1:5002"
+	powergateAddr = "127.0.0.1:5002"
 )
 
 func TestMain(m *testing.M) {
@@ -27,7 +27,7 @@ func TestSimpleSetup(t *testing.T) {
 	t.SkipNow()
 	_ = spinup(t)
 	ts := TestSetup{
-		PowergateAddr: lotusAddr,
+		PowergateAddr: powergateAddr,
 		MinerAddr:     "t01000",
 		SampleSize:    700,
 		MaxParallel:   1,
@@ -74,7 +74,7 @@ func spinup(t *testing.T) *client.Client {
 	limit := 30
 	retries := 0
 	for retries < limit {
-		c, err = client.NewClient(lotusAddr)
+		c, err = client.NewClient(powergateAddr)
 		require.NoError(t, err)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 		defer cancel()

--- a/cmd/powbench/runner/runner_test.go
+++ b/cmd/powbench/runner/runner_test.go
@@ -8,14 +8,13 @@ import (
 	"time"
 
 	logging "github.com/ipfs/go-log/v2"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 	"github.com/textileio/powergate/api/client"
 	"github.com/textileio/powergate/health"
 )
 
 var (
-	lotusAddr = multiaddr.StringCast("/ip4/127.0.0.1/tcp/5002")
+	lotusAddr = "127.0.0.1:5002"
 )
 
 func TestMain(m *testing.M) {
@@ -28,12 +27,12 @@ func TestSimpleSetup(t *testing.T) {
 	t.SkipNow()
 	_ = spinup(t)
 	ts := TestSetup{
-		LotusAddr:    lotusAddr,
-		MinerAddr:    "t01000",
-		SampleSize:   700,
-		MaxParallel:  1,
-		TotalSamples: 1,
-		RandSeed:     22,
+		PowergateAddr: lotusAddr,
+		MinerAddr:     "t01000",
+		SampleSize:    700,
+		MaxParallel:   1,
+		TotalSamples:  1,
+		RandSeed:      22,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()


### PR DESCRIPTION
I think at one point multi address was in style, but appears that was last season. All the current clients used in `textile` repo just use simple `host:port` string. Doing the same here will make it easier to integrate the Powergate `Client` into the same system.