### PR TITLE
Allow sharing of master address among ffs instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Usage of ./powd:
       --autocreatemasteraddr      Automatically creates & funds a master address if none is provided
       --debug                     Enable debug log level in all loggers.
       --devnet                    Indicate that will be running on an ephemeral devnet. --repopath will be autocleaned on exit.
+      --ffsusemasteraddr          Use the master address as the initial address for all new FFS instances instead of creating a new unique addess for each new FFS instance.
       --gatewayhostaddr string    Gateway host listening address (default "0.0.0.0:7000")
       --grpchostaddr string       gRPC host listening address. (default "/ip4/0.0.0.0/tcp/5002")
       --grpcwebproxyaddr string   gRPC webproxy listening address. (default "0.0.0.0:6002")

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To build from source, you need to have Go 1.14 or newer installed.
 
 ## Design
 
-Powergate is composed of different modules which can be used independently, and compose toegheter to provide other higher-level modules.
+Powergate is composed of different modules which can be used independently, and compose together to provide other higher-level modules.
 
 Here's a high-level overview of the main components, and how Powergate interacts with IPFS and a Filecoin client:
 ![Powergate Design](https://user-images.githubusercontent.com/6136245/86490337-6dbd5200-bd3d-11ea-9895-3689dd1c8a8f.png)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -99,6 +99,7 @@ type Config struct {
 	LotusAuthToken       string
 	LotusMasterAddr      string
 	AutocreateMasterAddr bool
+	FFSUseMasterAddr     bool
 	Devnet               bool
 	GrpcHostNetwork      string
 	GrpcHostAddress      ma.Multiaddr
@@ -210,7 +211,7 @@ func NewServer(conf Config) (*Server, error) {
 		return nil, fmt.Errorf("creating scheduler: %s", err)
 	}
 
-	ffsManager, err := manager.New(txndstr.Wrap(ds, "ffs/manager"), wm, pm, dm, sched)
+	ffsManager, err := manager.New(txndstr.Wrap(ds, "ffs/manager"), wm, pm, dm, sched, conf.FFSUseMasterAddr)
 	if err != nil {
 		return nil, fmt.Errorf("creating ffs instance: %s", err)
 	}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -112,6 +112,10 @@ type Config struct {
 
 // NewServer starts and returns a new server with the given configuration.
 func NewServer(conf Config) (*Server, error) {
+	if conf.FFSUseMasterAddr && !(len(conf.LotusMasterAddr) > 0 || conf.AutocreateMasterAddr) {
+		return nil, fmt.Errorf("FFSUseMasterAddr requires LotusMasterAddr or AutocreateMasterAddr to be provided")
+	}
+
 	var err error
 	var masterAddr address.Address
 	c, cls, err := lotus.New(conf.LotusAddress, conf.LotusAuthToken, lotusConnectionRetries)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -136,9 +136,10 @@ func NewServer(conf Config) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting Lotus network name: %s", err)
 	}
-	log.Infof("Detected Lotus node connected to network: %s", network)
+	networkName := string(network)
+	log.Infof("Detected Lotus node connected to network: %s", networkName)
 
-	fchost, err := fchost.New(string(network), !conf.Devnet)
+	fchost, err := fchost.New(networkName, !conf.Devnet)
 	if err != nil {
 		return nil, fmt.Errorf("creating filecoin host: %s", err)
 	}
@@ -181,7 +182,7 @@ func NewServer(conf Config) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating deal module: %s", err)
 	}
-	wm, err := walletModule.New(c, masterAddr, conf.WalletInitialFunds, conf.AutocreateMasterAddr)
+	wm, err := walletModule.New(c, masterAddr, conf.WalletInitialFunds, conf.AutocreateMasterAddr, networkName)
 	if err != nil {
 		return nil, fmt.Errorf("creating wallet module: %s", err)
 	}

--- a/cli-docs/pow/pow.md
+++ b/cli-docs/pow/pow.md
@@ -10,7 +10,7 @@ A client for storage and retreival of powergate data
 
 ```
   -h, --help                   help for pow
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_asks.md
+++ b/cli-docs/pow/pow_asks.md
@@ -15,7 +15,7 @@ Provides commands to view asks data
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_asks_get.md
+++ b/cli-docs/pow/pow_asks_get.md
@@ -19,7 +19,7 @@ pow asks get [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_asks_query.md
+++ b/cli-docs/pow/pow_asks_query.md
@@ -23,7 +23,7 @@ pow asks query [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_faults.md
+++ b/cli-docs/pow/pow_faults.md
@@ -15,7 +15,7 @@ Provides commands to view faults data
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_faults_get.md
+++ b/cli-docs/pow/pow_faults_get.md
@@ -19,7 +19,7 @@ pow faults get [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs.md
+++ b/cli-docs/pow/pow_ffs.md
@@ -15,7 +15,7 @@ Provides commands to manage ffs
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_addrs.md
+++ b/cli-docs/pow/pow_ffs_addrs.md
@@ -15,7 +15,7 @@ Provides commands to manage wallet addresses
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_addrs_list.md
+++ b/cli-docs/pow/pow_ffs_addrs_list.md
@@ -20,7 +20,7 @@ pow ffs addrs list [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_addrs_new.md
+++ b/cli-docs/pow/pow_ffs_addrs_new.md
@@ -22,7 +22,7 @@ pow ffs addrs new [name] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_cancel.md
+++ b/cli-docs/pow/pow_ffs_cancel.md
@@ -20,7 +20,7 @@ pow ffs cancel [jobid] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_close.md
+++ b/cli-docs/pow/pow_ffs_close.md
@@ -20,7 +20,7 @@ pow ffs close [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_config.md
+++ b/cli-docs/pow/pow_ffs_config.md
@@ -15,7 +15,7 @@ Provides commands to manage storage configuration
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_config_default.md
+++ b/cli-docs/pow/pow_ffs_config_default.md
@@ -20,7 +20,7 @@ pow ffs config default [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_config_get.md
+++ b/cli-docs/pow/pow_ffs_config_get.md
@@ -20,7 +20,7 @@ pow ffs config get [cid] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_config_push.md
+++ b/cli-docs/pow/pow_ffs_config_push.md
@@ -23,7 +23,7 @@ pow ffs config push [cid] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_config_set-default.md
+++ b/cli-docs/pow/pow_ffs_config_set-default.md
@@ -20,7 +20,7 @@ pow ffs config set-default [(optional)file] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_create.md
+++ b/cli-docs/pow/pow_ffs_create.md
@@ -19,7 +19,7 @@ pow ffs create [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_get.md
+++ b/cli-docs/pow/pow_ffs_get.md
@@ -20,7 +20,7 @@ pow ffs get [cid] [output file path] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_id.md
+++ b/cli-docs/pow/pow_ffs_id.md
@@ -20,7 +20,7 @@ pow ffs id [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_info.md
+++ b/cli-docs/pow/pow_ffs_info.md
@@ -20,7 +20,7 @@ pow ffs info [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_log.md
+++ b/cli-docs/pow/pow_ffs_log.md
@@ -21,7 +21,7 @@ pow ffs log [cid] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_paych.md
+++ b/cli-docs/pow/pow_ffs_paych.md
@@ -15,7 +15,7 @@ Provides commands to manage payment channels
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_paych_create.md
+++ b/cli-docs/pow/pow_ffs_paych_create.md
@@ -20,7 +20,7 @@ pow ffs paych create [from] [to] [amount] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_paych_list.md
+++ b/cli-docs/pow/pow_ffs_paych_list.md
@@ -20,7 +20,7 @@ pow ffs paych list [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_paych_redeem.md
+++ b/cli-docs/pow/pow_ffs_paych_redeem.md
@@ -20,7 +20,7 @@ pow ffs paych redeem [from] [to] [amount] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_remove.md
+++ b/cli-docs/pow/pow_ffs_remove.md
@@ -20,7 +20,7 @@ pow ffs remove [cid] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_replace.md
+++ b/cli-docs/pow/pow_ffs_replace.md
@@ -21,7 +21,7 @@ pow ffs replace [cid1] [cid2] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_retrievals.md
+++ b/cli-docs/pow/pow_ffs_retrievals.md
@@ -22,7 +22,7 @@ pow ffs retrievals [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_retrievals.md
+++ b/cli-docs/pow/pow_ffs_retrievals.md
@@ -17,6 +17,7 @@ pow ffs retrievals [flags]
   -a, --ascending       sort records ascending, default is descending
       --cids strings    limit the records to deals for the specified data cids
   -h, --help            help for retrievals
+  -t, --token string    token of the request
 ```
 
 ### Options inherited from parent commands

--- a/cli-docs/pow/pow_ffs_send.md
+++ b/cli-docs/pow/pow_ffs_send.md
@@ -20,7 +20,7 @@ pow ffs send [from address] [to address] [amount] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_show.md
+++ b/cli-docs/pow/pow_ffs_show.md
@@ -20,7 +20,7 @@ pow ffs show [cid] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_stage.md
+++ b/cli-docs/pow/pow_ffs_stage.md
@@ -20,7 +20,7 @@ pow ffs stage [path] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_storage.md
+++ b/cli-docs/pow/pow_ffs_storage.md
@@ -24,7 +24,7 @@ pow ffs storage [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_ffs_storage.md
+++ b/cli-docs/pow/pow_ffs_storage.md
@@ -19,6 +19,7 @@ pow ffs storage [flags]
   -h, --help              help for storage
   -f, --include-final     include final deals
   -p, --include-pending   include pending deals
+  -t, --token string      token of the request
 ```
 
 ### Options inherited from parent commands

--- a/cli-docs/pow/pow_ffs_watch.md
+++ b/cli-docs/pow/pow_ffs_watch.md
@@ -20,7 +20,7 @@ pow ffs watch [jobid,...] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_health.md
+++ b/cli-docs/pow/pow_health.md
@@ -19,7 +19,7 @@ pow health [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_miners.md
+++ b/cli-docs/pow/pow_miners.md
@@ -15,7 +15,7 @@ Provides commands to view miners data
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_miners_get.md
+++ b/cli-docs/pow/pow_miners_get.md
@@ -19,7 +19,7 @@ pow miners get [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_net.md
+++ b/cli-docs/pow/pow_net.md
@@ -15,7 +15,7 @@ Provides commands related to peers and network
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_net_addr.md
+++ b/cli-docs/pow/pow_net_addr.md
@@ -19,7 +19,7 @@ pow net addr [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_net_connect.md
+++ b/cli-docs/pow/pow_net_connect.md
@@ -19,7 +19,7 @@ pow net connect [peerID] [optional address] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_net_connectedness.md
+++ b/cli-docs/pow/pow_net_connectedness.md
@@ -19,7 +19,7 @@ pow net connectedness [peerID] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_net_disconnect.md
+++ b/cli-docs/pow/pow_net_disconnect.md
@@ -19,7 +19,7 @@ pow net disconnect [peerID] [address] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_net_find.md
+++ b/cli-docs/pow/pow_net_find.md
@@ -19,7 +19,7 @@ pow net find [peerID] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_net_peers.md
+++ b/cli-docs/pow/pow_net_peers.md
@@ -19,7 +19,7 @@ pow net peers [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_reputation.md
+++ b/cli-docs/pow/pow_reputation.md
@@ -15,7 +15,7 @@ Provides commands to view miner reputation data
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_reputation_addSource.md
+++ b/cli-docs/pow/pow_reputation_addSource.md
@@ -21,7 +21,7 @@ pow reputation addSource [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_reputation_topMiners.md
+++ b/cli-docs/pow/pow_reputation_topMiners.md
@@ -20,7 +20,7 @@ pow reputation topMiners [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_wallet.md
+++ b/cli-docs/pow/pow_wallet.md
@@ -15,7 +15,7 @@ Provides commands about filecoin wallets
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_wallet_balance.md
+++ b/cli-docs/pow/pow_wallet_balance.md
@@ -19,7 +19,7 @@ pow wallet balance [address] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_wallet_list.md
+++ b/cli-docs/pow/pow_wallet_list.md
@@ -19,7 +19,7 @@ pow wallet list [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_wallet_new.md
+++ b/cli-docs/pow/pow_wallet_new.md
@@ -20,7 +20,7 @@ pow wallet new [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cli-docs/pow/pow_wallet_send.md
+++ b/cli-docs/pow/pow_wallet_send.md
@@ -19,7 +19,7 @@ pow wallet send [from address] [to address] [amount] [flags]
 ### Options inherited from parent commands
 
 ```
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 ```
 
 ### SEE ALSO

--- a/cmd/pow/cmd/ffs_retrievals.go
+++ b/cmd/pow/cmd/ffs_retrievals.go
@@ -15,14 +15,15 @@ import (
 )
 
 func init() {
-	ffsrRetrievalsCmd.Flags().BoolP("ascending", "a", false, "sort records ascending, default is descending")
-	ffsrRetrievalsCmd.Flags().StringSlice("cids", []string{}, "limit the records to deals for the specified data cids")
-	ffsrRetrievalsCmd.Flags().StringSlice("addrs", []string{}, "limit the records to deals initiated from  the specified wallet addresses")
+	ffsRetrievalsCmd.Flags().StringP("token", "t", "", "token of the request")
+	ffsRetrievalsCmd.Flags().BoolP("ascending", "a", false, "sort records ascending, default is descending")
+	ffsRetrievalsCmd.Flags().StringSlice("cids", []string{}, "limit the records to deals for the specified data cids")
+	ffsRetrievalsCmd.Flags().StringSlice("addrs", []string{}, "limit the records to deals initiated from  the specified wallet addresses")
 
-	ffsCmd.AddCommand(ffsrRetrievalsCmd)
+	ffsCmd.AddCommand(ffsRetrievalsCmd)
 }
 
-var ffsrRetrievalsCmd = &cobra.Command{
+var ffsRetrievalsCmd = &cobra.Command{
 	Use:   "retrievals",
 	Short: "List retrieval deal records for an FFS instance",
 	Long:  `List retrieval deal records for an FFS instance`,

--- a/cmd/pow/cmd/ffs_storage.go
+++ b/cmd/pow/cmd/ffs_storage.go
@@ -15,6 +15,7 @@ import (
 )
 
 func init() {
+	ffsStorageCmd.Flags().StringP("token", "t", "", "token of the request")
 	ffsStorageCmd.Flags().BoolP("ascending", "a", false, "sort records ascending, default is sort descending")
 	ffsStorageCmd.Flags().StringSlice("cids", []string{}, "limit the records to deals for the specified data cids, treated as and AND operation if --addrs is also provided")
 	ffsStorageCmd.Flags().StringSlice("addrs", []string{}, "limit the records to deals initiated from  the specified wallet addresses, treated as and AND operation if --cids is also provided")

--- a/cmd/pow/cmd/root.go
+++ b/cmd/pow/cmd/root.go
@@ -45,7 +45,7 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().String("serverAddress", "/ip4/127.0.0.1/tcp/5002", "address of the powergate service api")
+	rootCmd.PersistentFlags().String("serverAddress", "127.0.0.1:5002", "address of the powergate service api")
 }
 
 func initConfig() {

--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -106,6 +106,7 @@ func configFromFlags() (server.Config, error) {
 	ipfsAPIAddr := util.MustParseAddr(config.GetString("ipfsapiaddr"))
 	lotusMasterAddr := config.GetString("lotusmasteraddr")
 	autocreateMasterAddr := config.GetBool("autocreatemasteraddr")
+	ffsUseMasterAddr := config.GetBool("ffsusemasteraddr")
 	grpcWebProxyAddr := config.GetString("grpcwebproxyaddr")
 	gatewayHostAddr := config.GetString("gatewayhostaddr")
 	maxminddbfolder := config.GetString("maxminddbfolder")
@@ -117,6 +118,7 @@ func configFromFlags() (server.Config, error) {
 		LotusAuthToken:       lotusToken,
 		LotusMasterAddr:      lotusMasterAddr,
 		AutocreateMasterAddr: autocreateMasterAddr,
+		FFSUseMasterAddr:     ffsUseMasterAddr,
 		Devnet:               devnet,
 		// ToDo: Support secure gRPC connection
 		GrpcHostNetwork:     "tcp",
@@ -269,6 +271,7 @@ func setupFlags() error {
 	pflag.String("lotustokenfile", "", "Path of a file that contains the Lotus API authorization token.")
 	pflag.String("lotusmasteraddr", "", "Existing wallet address in Lotus to be used as source of funding for new FFS instances. (Optional)")
 	pflag.Bool("autocreatemasteraddr", false, "Automatically creates & funds a master address if none is provided")
+	pflag.Bool("ffsusemasteraddr", false, "Use the master address as the initial address for all new FFS instances instead of creating a new unique addess for each new FFS instance.")
 	pflag.String("repopath", "~/.powergate", "Path of the repository where Powergate state will be saved.")
 	pflag.Bool("devnet", false, "Indicate that will be running on an ephemeral devnet. --repopath will be autocleaned on exit.")
 	pflag.String("ipfsapiaddr", "/ip4/127.0.0.1/tcp/5001", "IPFS API endpoint multiaddress. (Optional, only needed if FFS is used)")

--- a/ffs/api/api.go
+++ b/ffs/api/api.go
@@ -51,29 +51,18 @@ type API struct {
 }
 
 // New returns a new Api instance.
-func New(ctx context.Context, ds datastore.Datastore, iid ffs.APIID, sch *scheduler.Scheduler, wm ffs.WalletManager, pm ffs.PaychManager, drm ffs.DealRecordsManager, dc ffs.StorageConfig) (*API, error) {
+func New(ds datastore.Datastore, iid ffs.APIID, sch *scheduler.Scheduler, wm ffs.WalletManager, pm ffs.PaychManager, drm ffs.DealRecordsManager, dc ffs.StorageConfig, addrInfo AddrInfo) (*API, error) {
 	is := newInstanceStore(namespace.Wrap(ds, datastore.NewKey("istore")))
 
-	addr, err := wm.NewAddress(ctx, defaultAddressType)
-	if err != nil {
-		return nil, fmt.Errorf("creating new wallet addr: %s", err)
-	}
-
-	dc.Cold.Filecoin.Addr = addr
+	dc.Cold.Filecoin.Addr = addrInfo.Addr
 
 	if err := dc.Validate(); err != nil {
-		return nil, fmt.Errorf("default cid config is invalid: %s", err)
-	}
-
-	addrInfo := AddrInfo{
-		Name: "Initial Address",
-		Addr: addr,
-		Type: defaultAddressType,
+		return nil, fmt.Errorf("default storage config is invalid: %s", err)
 	}
 
 	config := Config{
 		ID:                   iid,
-		Addrs:                map[string]AddrInfo{addr: addrInfo},
+		Addrs:                map[string]AddrInfo{addrInfo.Addr: addrInfo},
 		DefaultStorageConfig: dc,
 	}
 

--- a/ffs/api/api_wallet.go
+++ b/ffs/api/api_wallet.go
@@ -6,10 +6,6 @@ import (
 	"math/big"
 )
 
-var (
-	defaultAddressType = "bls"
-)
-
 // Addrs returns the wallet addresses.
 func (i *API) Addrs() []AddrInfo {
 	i.lock.Lock()
@@ -28,7 +24,7 @@ func (i *API) NewAddr(ctx context.Context, name string, options ...NewAddressOpt
 
 	conf := &NewAddressConfig{
 		makeDefault: false,
-		addressType: defaultAddressType,
+		addressType: "bls",
 	}
 	for _, option := range options {
 		option(conf)

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1393,7 +1393,7 @@ func newFFSManager(t *testing.T, ds datastore.TxnDatastore, lotusClient *apistru
 
 	pm := paych.New(lotusClient)
 
-	manager, err := manager.New(ds, wm, pm, dm, sched)
+	manager, err := manager.New(ds, wm, pm, dm, sched, false)
 	require.NoError(t, err)
 	err = manager.SetDefaultStorageConfig(ffs.StorageConfig{
 		Hot: ffs.HotConfig{

--- a/ffs/integrationtest/integration_test.go
+++ b/ffs/integrationtest/integration_test.go
@@ -1388,7 +1388,7 @@ func newFFSManager(t *testing.T, ds datastore.TxnDatastore, lotusClient *apistru
 	sched, err := scheduler.New(txndstr.Wrap(ds, "ffs/scheduler"), l, hl, cl)
 	require.NoError(t, err)
 
-	wm, err := walletModule.New(lotusClient, masterAddr, *big.NewInt(iWalletBal), false)
+	wm, err := walletModule.New(lotusClient, masterAddr, *big.NewInt(iWalletBal), false, "")
 	require.NoError(t, err)
 
 	pm := paych.New(lotusClient)

--- a/ffs/interfaces.go
+++ b/ffs/interfaces.go
@@ -5,12 +5,15 @@ import (
 	"io"
 	"math/big"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-cid"
 	"github.com/textileio/powergate/deals"
 )
 
 // WalletManager provides access to a Lotus wallet for a Lotus node.
 type WalletManager interface {
+	// MasterAddr returns the master address.
+	MasterAddr() address.Address
 	// NewAddress creates a new address.
 	NewAddress(context.Context, string) (string, error)
 	// Balance returns the current balance for an address.

--- a/ffs/interfaces.go
+++ b/ffs/interfaces.go
@@ -13,6 +13,7 @@ import (
 // WalletManager provides access to a Lotus wallet for a Lotus node.
 type WalletManager interface {
 	// MasterAddr returns the master address.
+	// Will return address.Undef is Powergate was started with no master address.
 	MasterAddr() address.Address
 	// NewAddress creates a new address.
 	NewAddress(context.Context, string) (string, error)

--- a/ffs/manager/manager.go
+++ b/ffs/manager/manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
 	logging "github.com/ipfs/go-log/v2"
@@ -52,30 +53,32 @@ type Manager struct {
 	drm   ffs.DealRecordsManager
 	sched *scheduler.Scheduler
 
-	lock          sync.Mutex
-	ds            datastore.Datastore
-	auth          *auth.Auth
-	instances     map[ffs.APIID]*api.API
-	defaultConfig ffs.StorageConfig
+	lock             sync.Mutex
+	ds               datastore.Datastore
+	auth             *auth.Auth
+	instances        map[ffs.APIID]*api.API
+	defaultConfig    ffs.StorageConfig
+	ffsUseMasterAddr bool
 
 	closed bool
 }
 
 // New returns a new Manager.
-func New(ds datastore.Datastore, wm ffs.WalletManager, pm ffs.PaychManager, drm ffs.DealRecordsManager, sched *scheduler.Scheduler) (*Manager, error) {
+func New(ds datastore.Datastore, wm ffs.WalletManager, pm ffs.PaychManager, drm ffs.DealRecordsManager, sched *scheduler.Scheduler, ffsUseMasterAddr bool) (*Manager, error) {
 	storageConfig, err := loadDefaultStorageConfig(ds)
 	if err != nil {
 		return nil, fmt.Errorf("loading default storage config: %s", err)
 	}
 	return &Manager{
-		auth:          auth.New(namespace.Wrap(ds, datastore.NewKey("auth"))),
-		ds:            ds,
-		wm:            wm,
-		pm:            pm,
-		drm:           drm,
-		sched:         sched,
-		instances:     make(map[ffs.APIID]*api.API),
-		defaultConfig: storageConfig,
+		auth:             auth.New(namespace.Wrap(ds, datastore.NewKey("auth"))),
+		ds:               ds,
+		wm:               wm,
+		pm:               pm,
+		drm:              drm,
+		sched:            sched,
+		instances:        make(map[ffs.APIID]*api.API),
+		defaultConfig:    storageConfig,
+		ffsUseMasterAddr: ffsUseMasterAddr,
 	}, nil
 }
 
@@ -85,8 +88,40 @@ func (m *Manager) Create(ctx context.Context) (ffs.APIID, string, error) {
 	defer m.lock.Unlock()
 
 	log.Info("creating instance")
+
+	var addr address.Address
+	if m.ffsUseMasterAddr {
+		addr = m.wm.MasterAddr()
+	} else {
+		res, err := m.wm.NewAddress(ctx, "bls")
+		if err != nil {
+			return ffs.EmptyInstanceID, "", fmt.Errorf("creating new wallet addr: %s", err)
+		}
+		a, err := address.NewFromString(res)
+		if err != nil {
+			return ffs.EmptyInstanceID, "", fmt.Errorf("decoding newly created addr: %s", err)
+		}
+		addr = a
+	}
+
+	addrInfo := api.AddrInfo{Name: "Initial Address", Addr: addr.String()}
+	switch addr.Protocol() {
+	case address.BLS:
+		addrInfo.Type = "bls"
+	case address.SECP256K1:
+		addrInfo.Type = "secp256k1"
+	case address.Actor:
+		addrInfo.Type = "actor"
+	case address.ID:
+		addrInfo.Type = "id"
+	case address.Unknown:
+	default:
+		addrInfo.Type = "unknown"
+	}
+
 	iid := ffs.NewAPIID()
-	fapi, err := api.New(ctx, namespace.Wrap(m.ds, datastore.NewKey("api/"+iid.String())), iid, m.sched, m.wm, m.pm, m.drm, m.defaultConfig)
+
+	fapi, err := api.New(namespace.Wrap(m.ds, datastore.NewKey("api/"+iid.String())), iid, m.sched, m.wm, m.pm, m.drm, m.defaultConfig, addrInfo)
 	if err != nil {
 		return ffs.EmptyInstanceID, "", fmt.Errorf("creating new instance: %s", err)
 	}

--- a/ffs/manager/manager.go
+++ b/ffs/manager/manager.go
@@ -65,6 +65,9 @@ type Manager struct {
 
 // New returns a new Manager.
 func New(ds datastore.Datastore, wm ffs.WalletManager, pm ffs.PaychManager, drm ffs.DealRecordsManager, sched *scheduler.Scheduler, ffsUseMasterAddr bool) (*Manager, error) {
+	if ffsUseMasterAddr && wm.MasterAddr() == address.Undef {
+		return nil, fmt.Errorf("ffsUseMasterAddr requires that master address is defined")
+	}
 	storageConfig, err := loadDefaultStorageConfig(ds)
 	if err != nil {
 		return nil, fmt.Errorf("loading default storage config: %s", err)

--- a/ffs/manager/manager_test.go
+++ b/ffs/manager/manager_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/filecoin-project/go-address"
+	"github.com/filecoin-project/lotus/api/apistruct"
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/stretchr/testify/require"
@@ -23,17 +25,47 @@ func TestMain(m *testing.M) {
 
 func TestNewManager(t *testing.T) {
 	t.Parallel()
-	m, cls := newManager(t, tests.NewTxMapDatastore(), false)
+	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	m, cls, err := newManager(client, tests.NewTxMapDatastore(), addr, false)
+	require.NoError(t, err)
 	require.NotNil(t, m)
-	defer cls()
+	defer require.NoError(t, cls())
+}
+
+func TestNewManagerMasterAddrFFSUseMasterAddr(t *testing.T) {
+	t.Parallel()
+	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	m, cls, err := newManager(client, tests.NewTxMapDatastore(), addr, true)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	defer require.NoError(t, cls())
+}
+
+func TestNewManagerNoMasterAddrNoFFSUseMasterAddr(t *testing.T) {
+	t.Parallel()
+	client, _, _ := tests.CreateLocalDevnet(t, 1)
+	m, cls, err := newManager(client, tests.NewTxMapDatastore(), address.Undef, false)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	defer require.NoError(t, cls())
+}
+
+func TestNewManagerNoMasterAddrFFSUseMasterAddr(t *testing.T) {
+	t.Parallel()
+	client, _, _ := tests.CreateLocalDevnet(t, 1)
+	_, cls, err := newManager(client, tests.NewTxMapDatastore(), address.Undef, true)
+	require.Error(t, err)
+	defer require.NoError(t, cls())
 }
 
 func TestCreate(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ctx := context.Background()
-	m, cls := newManager(t, ds, false)
-	defer cls()
+	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	m, cls, err := newManager(client, ds, addr, false)
+	require.NoError(t, err)
+	defer require.NoError(t, cls())
 
 	id, auth, err := m.Create(ctx)
 	require.NoError(t, err)
@@ -45,8 +77,10 @@ func TestCreateWithFFSMasterAddr(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ctx := context.Background()
-	m, cls := newManager(t, ds, true)
-	defer cls()
+	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	m, cls, err := newManager(client, ds, addr, true)
+	require.NoError(t, err)
+	defer require.NoError(t, cls())
 
 	id, auth, err := m.Create(ctx)
 	require.NoError(t, err)
@@ -66,8 +100,10 @@ func TestList(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ctx := context.Background()
-	m, cls := newManager(t, ds, false)
-	defer cls()
+	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	m, cls, err := newManager(client, ds, addr, false)
+	require.NoError(t, err)
+	defer require.NoError(t, cls())
 
 	lst, err := m.List()
 	require.NoError(t, err)
@@ -94,8 +130,10 @@ func TestGetByAuthToken(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ctx := context.Background()
-	m, cls := newManager(t, ds, false)
-	defer cls()
+	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	m, cls, err := newManager(client, ds, addr, false)
+	require.NoError(t, err)
+	defer require.NoError(t, cls())
 	id, auth, err := m.Create(ctx)
 	require.NoError(t, err)
 
@@ -106,8 +144,10 @@ func TestGetByAuthToken(t *testing.T) {
 		require.NotEmpty(t, new.Addrs())
 	})
 	t.Run("Cold", func(t *testing.T) {
-		m, cls := newManager(t, ds, false)
-		defer cls()
+		client, addr, _ := tests.CreateLocalDevnet(t, 1)
+		m, cls, err := newManager(client, ds, addr, false)
+		require.NoError(t, err)
+		defer require.NoError(t, cls())
 		new, err := m.GetByAuthToken(auth)
 		require.NoError(t, err)
 		require.Equal(t, id, new.ID())
@@ -123,8 +163,10 @@ func TestGetByAuthToken(t *testing.T) {
 func TestDefaultStorageConfig(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
-	m, cls := newManager(t, ds, false)
-	defer cls()
+	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	m, cls, err := newManager(client, ds, addr, false)
+	require.NoError(t, err)
+	defer require.NoError(t, cls())
 
 	// A newly created manager must have
 	// the zeroConfig defined value.
@@ -134,32 +176,38 @@ func TestDefaultStorageConfig(t *testing.T) {
 	// Change the default config and test.
 	c.Hot.Enabled = false
 	c.Repairable = true
-	err := m.SetDefaultStorageConfig(c)
+	err = m.SetDefaultStorageConfig(c)
 	require.NoError(t, err)
 	c2 := m.GetDefaultStorageConfig()
 	require.Equal(t, c, c2)
-	cls()
+	defer require.NoError(t, cls())
 
 	// Re-open manager, and check that
 	// the default config was the last
 	// saved one, and not zeroConfig.
-	m, cls = newManager(t, ds, false)
-	defer cls()
+	m, cls, err = newManager(client, ds, addr, false)
+	require.NoError(t, err)
+	defer require.NoError(t, cls())
 	c3 := m.GetDefaultStorageConfig()
 	require.Equal(t, c, c3)
 }
 
-func newManager(t *testing.T, ds datastore.TxnDatastore, ffsUseMasterAddr bool) (*Manager, func()) {
-	client, addr, _ := tests.CreateLocalDevnet(t, 1)
-	wm, err := walletModule.New(client, addr, *big.NewInt(4000000000), false, "")
-	require.NoError(t, err)
+func newManager(client *apistruct.FullNodeStruct, ds datastore.TxnDatastore, masterAddr address.Address, ffsUseMasterAddr bool) (*Manager, func() error, error) {
+	wm, err := walletModule.New(client, masterAddr, *big.NewInt(4000000000), false, "")
+	if err != nil {
+		return nil, func() error { return nil }, err
+	}
 	pm := paych.New(client)
 	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), client)
-	require.NoError(t, err)
-	m, err := New(ds, wm, pm, dm, nil, ffsUseMasterAddr)
-	require.NoError(t, err)
-	cls := func() {
-		require.Nil(t, m.Close())
+	if err != nil {
+		return nil, func() error { return nil }, err
 	}
-	return m, cls
+	m, err := New(ds, wm, pm, dm, nil, ffsUseMasterAddr)
+	if err != nil {
+		return nil, func() error { return nil }, err
+	}
+	cls := func() error {
+		return m.Close()
+	}
+	return m, cls, nil
 }

--- a/ffs/manager/manager_test.go
+++ b/ffs/manager/manager_test.go
@@ -130,7 +130,7 @@ func TestDefaultStorageConfig(t *testing.T) {
 
 func newManager(t *testing.T, ds datastore.TxnDatastore) (*Manager, func()) {
 	client, addr, _ := tests.CreateLocalDevnet(t, 1)
-	wm, err := walletModule.New(client, addr, *big.NewInt(4000000000), false)
+	wm, err := walletModule.New(client, addr, *big.NewInt(4000000000), false, "")
 	require.NoError(t, err)
 	pm := paych.New(client)
 	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), client)

--- a/go.mod
+++ b/go.mod
@@ -55,3 +55,5 @@ require (
 	google.golang.org/grpc v1.30.0
 	google.golang.org/protobuf v1.25.0
 )
+
+replace github.com/dgraph-io/badger/v2 => github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200718033852-37ee16d8ad1c

--- a/go.sum
+++ b/go.sum
@@ -195,12 +195,12 @@ github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Ev
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.1 h1:w9pSFNSdq/JPM1N12Fz/F/bzo993Is1W+Q7HjPzi7yg=
 github.com/dgraph-io/badger v1.6.1/go.mod h1:FRmFw3uxvcpa8zG3Rxs0th+hCLIuaQg8HlNV5bjgnuU=
-github.com/dgraph-io/badger/v2 v2.0.3 h1:inzdf6VF/NZ+tJ8RwwYMjJMvsOALTHYdozn0qSl6XJI=
-github.com/dgraph-io/badger/v2 v2.0.3/go.mod h1:3KY8+bsP8wI0OEnQJAKpd4wIJW/Mm32yw2j/9FUVnIM=
-github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3 h1:MQLRM35Pp0yAyBYksjbj1nZI/w6eyRY/mWoM1sFf4kU=
-github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200718033852-37ee16d8ad1c h1:LoEZfU53r3H1et4WY9M0h1c3fuCljBnn3pk/7TB5eWY=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200718033852-37ee16d8ad1c/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=

--- a/wallet/module/wallet.go
+++ b/wallet/module/wallet.go
@@ -64,6 +64,11 @@ func New(api *apistruct.FullNodeStruct, maddr address.Address, iam big.Int, auto
 	return m, nil
 }
 
+// MasterAddr returns the master address.
+func (m *Module) MasterAddr() address.Address {
+	return m.masterAddr
+}
+
 // NewAddress creates a new address.
 func (m *Module) NewAddress(ctx context.Context, typ string) (string, error) {
 	var ty crypto.SigType

--- a/wallet/module/wallet.go
+++ b/wallet/module/wallet.go
@@ -65,6 +65,7 @@ func New(api *apistruct.FullNodeStruct, maddr address.Address, iam big.Int, auto
 }
 
 // MasterAddr returns the master address.
+// Will return address.Undef is Powergate was started with no master address.
 func (m *Module) MasterAddr() address.Address {
 	return m.masterAddr
 }

--- a/wallet/rpc/rpc.proto
+++ b/wallet/rpc/rpc.proto
@@ -20,7 +20,7 @@ message ListResponse {
 }
 
 message BalanceRequest {
-	string address = 1;
+    string address = 1;
 }
 
 message BalanceResponse {


### PR DESCRIPTION
Achieved through a configuration flag. Pretty straight forward and supports Piñata's use case.