### PR TITLE
fix make default rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL=build
+
 include .bingo/Variables.mk
 
 BUILD_FLAGS=CGO_ENABLED=0


### PR DESCRIPTION
The new `include` rule in the Makefile changed the default rule, so `make` doesn't generate and installs all binaries.
Define the default rule explicitly.