### PR TITLE
Stage folders support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The binary will be placed automatically in `$GOPATH/bin` which in general is in 
 You can read the [generated CLI docs](https://github.com/textileio/powergate/blob/master/cli-docs/pow/pow.md) in this repo, or run `pow` with the `--help` flag to see the available commands:
 
 ```
+
 $ pow --help
 A client for storage and retreival of powergate data
 
@@ -83,22 +84,18 @@ Usage:
 
 Available Commands:
   asks        Provides commands to view asks data
-  deal        Interactive storage deal
-  deals       Provides commands to manage storage deals
+  faults      Provides commands to view faults data
   ffs         Provides commands to manage ffs
   health      Display the node health status
   help        Help about any command
-  init        Initializes a config file with the provided values or defaults
   miners      Provides commands to view miners data
   net         Provides commands related to peers and network
   reputation  Provides commands to view miner reputation data
-  faults      Provides commands to view faults data
   wallet      Provides commands about filecoin wallets
 
 Flags:
-      --config string          config file (default is $HOME/.powergate.yaml)
   -h, --help                   help for pow
-      --serverAddress string   address of the powergate service api (default "/ip4/127.0.0.1/tcp/5002")
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
 
 Use "pow [command] --help" for more information about a command.
 ```
@@ -140,7 +137,7 @@ make build-powd
 You can run the `-h` flag to see the configurable flags:
 ```bash
 $ powd -h
-Usage of ./powd:
+Usage of powd:
       --autocreatemasteraddr      Automatically creates & funds a master address if none is provided
       --debug                     Enable debug log level in all loggers.
       --devnet                    Indicate that will be running on an ephemeral devnet. --repopath will be autocleaned on exit.
@@ -149,6 +146,7 @@ Usage of ./powd:
       --grpchostaddr string       gRPC host listening address. (default "/ip4/0.0.0.0/tcp/5002")
       --grpcwebproxyaddr string   gRPC webproxy listening address. (default "0.0.0.0:6002")
       --ipfsapiaddr string        IPFS API endpoint multiaddress. (Optional, only needed if FFS is used) (default "/ip4/127.0.0.1/tcp/5001")
+      --ipfsrevproxyaddr string   IPFS reverse proxy listen address (default "127.0.0.1:6003")
       --lotushost string          Lotus client API endpoint multiaddress. (default "/ip4/127.0.0.1/tcp/1234")
       --lotusmasteraddr string    Existing wallet address in Lotus to be used as source of funding for new FFS instances. (Optional)
       --lotustoken string         Lotus API authorization token. This flag or --lotustoken file are mandatory.
@@ -156,7 +154,6 @@ Usage of ./powd:
       --maxminddbfolder string    Path of the folder containing GeoLite2-City.mmdb (default ".")
       --repopath string           Path of the repository where Powergate state will be saved. (default "~/.powergate")
       --walletinitialfund int     FFS initial funding transaction amount in attoFIL received by --lotusmasteraddr. (if set) (default 4000000000000000)
-pflag: help requested
 ```
 
 We'll soon provide better information about Powergate configurations, stay tuned! 📻

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -264,9 +264,6 @@ func NewServer(conf Config) (*Server, error) {
 	}
 
 	s.indexServer = startIndexHTTPServer(s)
-	if err != nil {
-		return nil, fmt.Errorf("starting index server: %s", err)
-	}
 
 	s.ipfsRevProxy, err = startIPFSRevProxy(&conf, ffsManager)
 	if err != nil {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -7,6 +7,8 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -89,8 +91,9 @@ type Server struct {
 	grpcServer   *grpc.Server
 	grpcWebProxy *http.Server
 
-	gateway     *gateway.Gateway
-	indexServer *http.Server
+	gateway      *gateway.Gateway
+	indexServer  *http.Server
+	ipfsRevProxy *http.Server
 
 	closeLotus func()
 }
@@ -111,6 +114,7 @@ type Config struct {
 	GrpcWebProxyAddress  string
 	RepoPath             string
 	GatewayHostAddr      string
+	IPFSRevProxyAddr     string
 	MaxMindDBFolder      string
 }
 
@@ -260,10 +264,44 @@ func NewServer(conf Config) (*Server, error) {
 	}
 
 	s.indexServer = startIndexHTTPServer(s)
+	if err != nil {
+		return nil, fmt.Errorf("starting IPFS reverse proxy: %s", err)
+	}
+
+	s.ipfsRevProxy, err = startIPFSRevProxy(s, &conf)
 
 	log.Info("Starting finished, serving requests")
 
 	return s, nil
+}
+
+func startIPFSRevProxy(server *Server, conf *Config) (*http.Server, error) {
+	if conf.IPFSRevProxyAddr == "" {
+		return nil, nil
+	}
+
+	log.Info("Starting IPFS reverse proxy...")
+	ipfsIP, err := util.TCPAddrFromMultiAddr(conf.IpfsAPIAddr)
+	if err != nil {
+		return nil, fmt.Errorf("converting IPFS multiaddr to tcp addr: %s", err)
+	}
+
+	urlIPFS, err := url.Parse("http://" + ipfsIP)
+	if err != nil {
+		return nil, fmt.Errorf("generating IPFS URL for reverse proxy: %s", err)
+	}
+	rph := httputil.NewSingleHostReverseProxy(urlIPFS)
+	rp := &http.Server{
+		Addr:    conf.IPFSRevProxyAddr,
+		Handler: rph,
+	}
+
+	go func() {
+		if err := rp.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("serving index http: %v", err)
+		}
+	}()
+	return rp, nil
 }
 
 func createGRPCServer(opts []grpc.ServerOption, webProxyAddr string) (*grpc.Server, *http.Server) {
@@ -384,17 +422,26 @@ func startIndexHTTPServer(s *Server) *http.Server {
 
 // Close shuts down the server.
 func (s *Server) Close() {
+	if s.ipfsRevProxy != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := s.ipfsRevProxy.Shutdown(ctx); err != nil {
+			log.Errorf("closing down ipfs reverse proxy: %s", err)
+		}
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
+
 	if err := s.indexServer.Shutdown(ctx); err != nil {
-		log.Errorf("shutting down index server: %s", err)
+		log.Errorf("closing down index server: %s", err)
 	}
 
 	log.Info("closing gRPC endpoints...")
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := s.grpcWebProxy.Shutdown(ctx); err != nil {
-		log.Errorf("error shutting down proxy: %s", err)
+		log.Errorf("closing down proxy: %s", err)
 	}
 	stopped := make(chan struct{})
 	go func() {

--- a/cli-docs/pow/pow_ffs.md
+++ b/cli-docs/pow/pow_ffs.md
@@ -36,7 +36,7 @@ Provides commands to manage ffs
 * [pow ffs retrievals](pow_ffs_retrievals.md)	 - List retrieval deal records for an FFS instance
 * [pow ffs send](pow_ffs_send.md)	 - Send fil from one managed address to any other address
 * [pow ffs show](pow_ffs_show.md)	 - Show pinned cid data
-* [pow ffs stage](pow_ffs_stage.md)	 - Temporarily cache data in the Hot layer in preparation for pushing a cid storage config
+* [pow ffs stage](pow_ffs_stage.md)	 - Temporarily stage data in the Hot layer in preparation for pushing a cid storage config
 * [pow ffs storage](pow_ffs_storage.md)	 - List storage deal records for an FFS instance
 * [pow ffs watch](pow_ffs_watch.md)	 - Watch for job status updates
 

--- a/cli-docs/pow/pow_ffs_get.md
+++ b/cli-docs/pow/pow_ffs_get.md
@@ -13,8 +13,10 @@ pow ffs get [cid] [output file path] [flags]
 ### Options
 
 ```
-  -h, --help           help for get
-  -t, --token string   token of the request
+  -f, --folder                Indicates that the retrieved Cid is a folder
+  -h, --help                  help for get
+      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "/ip4/127.0.0.1/tcp/6003")
+  -t, --token string          token of the request
 ```
 
 ### Options inherited from parent commands

--- a/cli-docs/pow/pow_ffs_get.md
+++ b/cli-docs/pow/pow_ffs_get.md
@@ -15,7 +15,7 @@ pow ffs get [cid] [output file path] [flags]
 ```
   -f, --folder                Indicates that the retrieved Cid is a folder
   -h, --help                  help for get
-      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "/ip4/127.0.0.1/tcp/6003")
+      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6003")
   -t, --token string          token of the request
 ```
 

--- a/cli-docs/pow/pow_ffs_stage.md
+++ b/cli-docs/pow/pow_ffs_stage.md
@@ -14,7 +14,7 @@ pow ffs stage [path] [flags]
 
 ```
   -h, --help                  help for stage
-      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "/ip4/127.0.0.1/tcp/6003")
+      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6003")
   -t, --token string          FFS access token
 ```
 

--- a/cli-docs/pow/pow_ffs_stage.md
+++ b/cli-docs/pow/pow_ffs_stage.md
@@ -1,10 +1,10 @@
 ## pow ffs stage
 
-Temporarily cache data in the Hot layer in preparation for pushing a cid storage config
+Temporarily stage data in the Hot layer in preparation for pushing a cid storage config
 
 ### Synopsis
 
-Temporarily cache data in the Hot layer in preparation for pushing a cid storage config
+Temporarily stage data in the Hot layer in preparation for pushing a cid storage config
 
 ```
 pow ffs stage [path] [flags]
@@ -13,8 +13,9 @@ pow ffs stage [path] [flags]
 ### Options
 
 ```
-  -h, --help           help for stage
-  -t, --token string   FFS access token
+  -h, --help                  help for stage
+      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "/ip4/127.0.0.1/tcp/6003")
+  -t, --token string          FFS access token
 ```
 
 ### Options inherited from parent commands

--- a/cmd/pow/cmd/ffs_get.go
+++ b/cmd/pow/cmd/ffs_get.go
@@ -94,11 +94,11 @@ func getFolder(ctx context.Context, c cid.Cid, outputPath string) error {
 	}
 	n, err := ipfs.Unixfs().Get(ctx, ipfspath.IpfsPath(c))
 	if err != nil {
-		checkErr(err)
+		return fmt.Errorf("getting folder DAG from IPFS: %s", err)
 	}
 	err = files.WriteTo(n, outputPath)
 	if err != nil {
-		checkErr(err)
+		return fmt.Errorf("saving folder DAG to output folder: %s", err)
 	}
 	return nil
 }

--- a/cmd/pow/cmd/ffs_get.go
+++ b/cmd/pow/cmd/ffs_get.go
@@ -46,7 +46,7 @@ var ffsGetCmd = &cobra.Command{
 		s := spin.New("%s Retrieving specified data...")
 		s.Start()
 
-		isFolder := viper.GetBool("isfolder")
+		isFolder := viper.GetBool("folder")
 		if isFolder {
 			err := getFolder(ctx, c, args[1])
 			checkErr(err)

--- a/cmd/pow/cmd/ffs_stage.go
+++ b/cmd/pow/cmd/ffs_stage.go
@@ -49,7 +49,6 @@ var ffsStageCmd = &cobra.Command{
 		s.Start()
 		if fi.IsDir() {
 			cid, err = fcClient.FFS.StageFolder(authCtx(ctx), viper.GetString("ipfsrevproxy"), args[0])
-			s.Stop()
 			checkErr(err)
 		} else {
 			f, err := os.Open(args[0])

--- a/cmd/pow/cmd/ffs_stage.go
+++ b/cmd/pow/cmd/ffs_stage.go
@@ -20,7 +20,7 @@ import (
 
 func init() {
 	ffsStageCmd.Flags().StringP("token", "t", "", "FFS access token")
-	ffsStageCmd.Flags().String("ipfsproxy", "/ip4/127.0.0.1/tcp/6003", "Powergate IPFS reverse proxy multiaddr")
+	ffsStageCmd.Flags().String("ipfsrevproxy", "/ip4/127.0.0.1/tcp/6003", "Powergate IPFS reverse proxy multiaddr")
 
 	ffsCmd.AddCommand(ffsStageCmd)
 }
@@ -71,7 +71,7 @@ var ffsStageCmd = &cobra.Command{
 }
 
 func addFolder(folderPath string) (cid.Cid, error) {
-	ipfsProxy := viper.GetString("ipfsproxy")
+	ipfsProxy := viper.GetString("ipfsrevproxy")
 	ma, _ := multiaddr.NewMultiaddr(ipfsProxy)
 	ipfs, err := httpapi.NewApi(ma)
 	if err != nil {

--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -282,7 +282,7 @@ func setupFlags() error {
 	pflag.String("ipfsapiaddr", "/ip4/127.0.0.1/tcp/5001", "IPFS API endpoint multiaddress. (Optional, only needed if FFS is used)")
 	pflag.Int64("walletinitialfund", 4000000000000000, "FFS initial funding transaction amount in attoFIL received by --lotusmasteraddr. (if set)")
 	pflag.String("gatewayhostaddr", "0.0.0.0:7000", "Gateway host listening address")
-	pflag.String("ipfsrevproxyaddr", "", "IPFS reverse proxy listen address")
+	pflag.String("ipfsrevproxyaddr", "127.0.0.1:6003", "IPFS reverse proxy listen address")
 	pflag.String("maxminddbfolder", ".", "Path of the folder containing GeoLite2-City.mmdb")
 	pflag.Parse()
 

--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -112,6 +112,7 @@ func configFromFlags() (server.Config, error) {
 	ffsUseMasterAddr := config.GetBool("ffsusemasteraddr")
 	grpcWebProxyAddr := config.GetString("grpcwebproxyaddr")
 	gatewayHostAddr := config.GetString("gatewayhostaddr")
+	ipfsRevProxyAddr := config.GetString("ipfsrevproxyaddr")
 	maxminddbfolder := config.GetString("maxminddbfolder")
 
 	return server.Config{
@@ -129,6 +130,7 @@ func configFromFlags() (server.Config, error) {
 		GrpcWebProxyAddress: grpcWebProxyAddr,
 		RepoPath:            repoPath,
 		GatewayHostAddr:     gatewayHostAddr,
+		IPFSRevProxyAddr:    ipfsRevProxyAddr,
 		MaxMindDBFolder:     maxminddbfolder,
 	}, nil
 }
@@ -280,6 +282,7 @@ func setupFlags() error {
 	pflag.String("ipfsapiaddr", "/ip4/127.0.0.1/tcp/5001", "IPFS API endpoint multiaddress. (Optional, only needed if FFS is used)")
 	pflag.Int64("walletinitialfund", 4000000000000000, "FFS initial funding transaction amount in attoFIL received by --lotusmasteraddr. (if set)")
 	pflag.String("gatewayhostaddr", "0.0.0.0:7000", "Gateway host listening address")
+	pflag.String("ipfsrevproxyaddr", "", "IPFS reverse proxy listen address")
 	pflag.String("maxminddbfolder", ".", "Path of the folder containing GeoLite2-City.mmdb")
 	pflag.Parse()
 

--- a/docker/docker-compose-localnet.yaml
+++ b/docker/docker-compose-localnet.yaml
@@ -17,6 +17,7 @@ services:
       - POWD_DEVNET=true
       - POWD_LOTUSHOST=/dns4/lotus/tcp/7777
       - POWD_IPFSAPIADDR=/dns4/ipfs/tcp/5001
+      - POWD_IPFSREVPROXYADDR=0.0.0.0:6003
     restart: unless-stopped
 
   ipfs:

--- a/docker/docker-compose-localnet.yaml
+++ b/docker/docker-compose-localnet.yaml
@@ -9,6 +9,7 @@ services:
       - 6060:6060
       - 5002:5002
       - 6002:6002
+      - 6003:6003
     depends_on:
       - ipfs
       - lotus


### PR DESCRIPTION
This adds functionality to `pow ffs stage` to support adding folders to IPFS.

The `pow` cli automatically detects if the added path is a file or folder. If it is a folder, it adds the folder using the IPFS HTTP API.

I didn't like the idea of exposing the IPFS node as an extra configuration knob, and also because that would mean it will be totally unauthenticated. To solve this, I created a reverse proxy in `powd`. This reverse proxy demands that all request have an authentication token which should be a valid _FFS token_, so any IPFS HTTP API call should come from an authenticated FFS instance.

Since `pow` is using the IPFS HTTP client library, I added slightly modified HTTP client transport which always adds the FFS token, so to satisfy the reverse proxy demands without building a different client.

This reverse proxy can be disabled, so `powd` isn't forced to enable this feature since I think in advance scenarios applications will be doing this actions directly in the IPFS node.

An example flow:
```
$ pow ffs create
<grab the ffs token>
$ pow ffs stage -t <ffs-token> myfolder
<grab folder cid>
$ pow ffs config push -t <ffs-token> <folder-cid>
<... wait for saving data>
$ pow ffs get -t <ffs-token> -f <folder_cid> <output-dir>
```

Some notes:
- `pow ffs stage` autodetect if the target path is a folder or dir using `os` package and acting accordingly.
- `pow ffs get` has a new flag `-f` to indicate that the Cid to be retrieved is a folder. Even if that flag is missed and is tried to retrieve as a file, an error indicating that "Sorry, this is a folder" will appear so the user can notice.
- The folder content is placed in `<output-dir>`.

Closes #504 

