### PR TITLE
Single Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ Usage of powd:
       --grpchostaddr string       gRPC host listening address. (default "/ip4/0.0.0.0/tcp/5002")
       --grpcwebproxyaddr string   gRPC webproxy listening address. (default "0.0.0.0:6002")
       --ipfsapiaddr string        IPFS API endpoint multiaddress. (Optional, only needed if FFS is used) (default "/ip4/127.0.0.1/tcp/5001")
-      --ipfsrevproxyaddr string   IPFS reverse proxy listen address (default "127.0.0.1:6003")
       --lotushost string          Lotus client API endpoint multiaddress. (default "/ip4/127.0.0.1/tcp/1234")
       --lotusmasteraddr string    Existing wallet address in Lotus to be used as source of funding for new FFS instances. (Optional)
       --lotustoken string         Lotus API authorization token. This flag or --lotustoken file are mandatory.

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -96,7 +96,7 @@ func NewClient(target string, optsOverrides ...grpc.DialOption) (*Client, error)
 		Faults:     &Faults{client: faultsRpc.NewRPCServiceClient(conn)},
 		Wallet:     &Wallet{client: walletRpc.NewRPCServiceClient(conn)},
 		Reputation: &Reputation{client: reputationRpc.NewRPCServiceClient(conn)},
-		FFS:        &FFS{client: ffsRpc.NewRPCServiceClient(conn)},
+		FFS:        &FFS{client: ffsRpc.NewRPCServiceClient(conn), target: target},
 		Health:     &Health{client: healthRpc.NewRPCServiceClient(conn)},
 		Net:        &Net{client: netRpc.NewRPCServiceClient(conn)},
 		conn:       conn,

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -96,7 +96,7 @@ func NewClient(target string, optsOverrides ...grpc.DialOption) (*Client, error)
 		Faults:     &Faults{client: faultsRpc.NewRPCServiceClient(conn)},
 		Wallet:     &Wallet{client: walletRpc.NewRPCServiceClient(conn)},
 		Reputation: &Reputation{client: reputationRpc.NewRPCServiceClient(conn)},
-		FFS:        &FFS{client: ffsRpc.NewRPCServiceClient(conn), target: target},
+		FFS:        &FFS{client: ffsRpc.NewRPCServiceClient(conn)},
 		Health:     &Health{client: healthRpc.NewRPCServiceClient(conn)},
 		Net:        &Net{client: netRpc.NewRPCServiceClient(conn)},
 		conn:       conn,

--- a/api/client/ffs.go
+++ b/api/client/ffs.go
@@ -27,7 +27,6 @@ import (
 // FFS provides the API to create and interact with an FFS instance.
 type FFS struct {
 	client rpc.RPCServiceClient
-	target string
 }
 
 // JobEvent represents an event for Watching a job.
@@ -381,9 +380,9 @@ func (f *FFS) Remove(ctx context.Context, c cid.Cid) error {
 }
 
 // GetFolder retrieves to outputDir a Cid which corresponds to a folder.
-func (f *FFS) GetFolder(ctx context.Context, c cid.Cid, outputDir string) error {
+func (f *FFS) GetFolder(ctx context.Context, ipfsRevProxyAddr string, c cid.Cid, outputDir string) error {
 	token := ctx.Value(AuthKey).(string)
-	ipfs, err := newDecoratedIPFSAPI(f.target, token)
+	ipfs, err := newDecoratedIPFSAPI(ipfsRevProxyAddr, token)
 	if err != nil {
 		return fmt.Errorf("creating decorated IPFS client: %s", err)
 	}
@@ -528,10 +527,10 @@ func (f *FFS) Stage(ctx context.Context, data io.Reader) (*cid.Cid, error) {
 }
 
 // StageFolder allows to temporarily stage a folder in the Hot Storage in preparation for pushing a cid storage config.
-func (f *FFS) StageFolder(ctx context.Context, folderPath string) (cid.Cid, error) {
+func (f *FFS) StageFolder(ctx context.Context, ipfsRevProxyAddr string, folderPath string) (cid.Cid, error) {
 	ffsToken := ctx.Value(AuthKey).(string)
 
-	ipfs, err := newDecoratedIPFSAPI(f.target, ffsToken)
+	ipfs, err := newDecoratedIPFSAPI(ipfsRevProxyAddr, ffsToken)
 	if err != nil {
 		return cid.Undef, fmt.Errorf("creating IPFS HTTP client: %s", err)
 	}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -230,11 +230,11 @@ func NewServer(conf Config) (*Server, error) {
 	log.Info("Starting gRPC, gateway and index HTTP servers...")
 	grpcServer := grpc.NewServer(conf.GrpcServerOpts...)
 	wrappedGRPCServer := wrapGRPCServer(grpcServer)
-	httpFFSAuthInerceptor, err := newHTTPFFSAuthInterceptor(conf, ffsManager)
+	httpFFSAuthInterceptor, err := newHTTPFFSAuthInterceptor(conf, ffsManager)
 	if err != nil {
 		return nil, fmt.Errorf("creating ffsHTTPAuth: %s", err)
 	}
-	webProxy := createProxyServer(wrappedGRPCServer, httpFFSAuthInerceptor, conf.GrpcWebProxyAddress)
+	webProxy := createProxyServer(wrappedGRPCServer, httpFFSAuthInterceptor, conf.GrpcWebProxyAddress)
 
 	gateway := gateway.NewGateway(conf.GatewayHostAddr, ai, mi, si, rm)
 	gateway.Start()

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -88,12 +88,12 @@ type Server struct {
 	hs         ffs.HotStorage
 	l          *cidlogger.CidLogger
 
-	grpcServer   *grpc.Server
-	grpcWebProxy *http.Server
+	grpcServer *grpc.Server
 
-	gateway      *gateway.Gateway
-	indexServer  *http.Server
-	ipfsRevProxy *http.Server
+	webProxy *http.Server
+
+	gateway     *gateway.Gateway
+	indexServer *http.Server
 
 	closeLotus func()
 }
@@ -114,7 +114,6 @@ type Config struct {
 	GrpcWebProxyAddress  string
 	RepoPath             string
 	GatewayHostAddr      string
-	IPFSRevProxyAddr     string
 	MaxMindDBFolder      string
 }
 
@@ -229,7 +228,13 @@ func NewServer(conf Config) (*Server, error) {
 	}
 
 	log.Info("Starting gRPC, gateway and index HTTP servers...")
-	grpcServer, grpcWebProxy := createGRPCServer(conf.GrpcServerOpts, conf.GrpcWebProxyAddress)
+	grpcServer := grpc.NewServer(conf.GrpcServerOpts...)
+	wrappedGRPCServer := wrapGRPCServer(grpcServer)
+	httpFFSAuthInerceptor, err := newHTTPFFSAuthInterceptor(conf, ffsManager)
+	if err != nil {
+		return nil, fmt.Errorf("creating ffsHTTPAuth: %s", err)
+	}
+	webProxy := createProxyServer(wrappedGRPCServer, httpFFSAuthInerceptor, conf.GrpcWebProxyAddress)
 
 	gateway := gateway.NewGateway(conf.GatewayHostAddr, ai, mi, si, rm)
 	gateway.Start()
@@ -253,22 +258,17 @@ func NewServer(conf Config) (*Server, error) {
 		hs:         hs,
 		l:          l,
 
-		grpcServer:   grpcServer,
-		grpcWebProxy: grpcWebProxy,
-		gateway:      gateway,
-		closeLotus:   cls,
+		grpcServer: grpcServer,
+		webProxy:   webProxy,
+		gateway:    gateway,
+		closeLotus: cls,
 	}
 
-	if err := startGRPCServices(grpcServer, grpcWebProxy, s, conf.GrpcHostNetwork, conf.GrpcHostAddress); err != nil {
+	if err := startGRPCServices(grpcServer, webProxy, s, conf.GrpcHostNetwork, conf.GrpcHostAddress); err != nil {
 		return nil, fmt.Errorf("starting GRPC services: %s", err)
 	}
 
 	s.indexServer = startIndexHTTPServer(s)
-
-	s.ipfsRevProxy, err = startIPFSRevProxy(&conf, ffsManager)
-	if err != nil {
-		return nil, fmt.Errorf("starting IPFS reverse proxy: %s", err)
-	}
 
 	log.Info("Starting finished, serving requests")
 
@@ -278,15 +278,27 @@ func NewServer(conf Config) (*Server, error) {
 type ffsHTTPAuth struct {
 	cont       http.Handler
 	ffsManager *manager.Manager
+	url        *url.URL
 }
 
-func newHTTPFFSAuthInterceptor(cont http.Handler, m *manager.Manager) *ffsHTTPAuth {
-	fha := &ffsHTTPAuth{
-		cont:       cont,
-		ffsManager: m,
+func newHTTPFFSAuthInterceptor(conf Config, m *manager.Manager) (*ffsHTTPAuth, error) {
+	log.Info("Starting IPFS reverse proxy...")
+	ipfsIP, err := util.TCPAddrFromMultiAddr(conf.IpfsAPIAddr)
+	if err != nil {
+		return nil, fmt.Errorf("converting IPFS multiaddr to tcp addr: %s", err)
 	}
 
-	return fha
+	urlIPFS, err := url.Parse("http://" + ipfsIP)
+	if err != nil {
+		return nil, fmt.Errorf("generating IPFS URL for reverse proxy: %s", err)
+	}
+	rph := httputil.NewSingleHostReverseProxy(urlIPFS)
+	fha := &ffsHTTPAuth{
+		cont:       rph,
+		ffsManager: m,
+		url:        urlIPFS,
+	}
+	return fha, nil
 }
 
 func (fha *ffsHTTPAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
@@ -299,39 +311,28 @@ func (fha *ffsHTTPAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	fha.cont.ServeHTTP(rw, r)
 }
 
-func startIPFSRevProxy(conf *Config, m *manager.Manager) (*http.Server, error) {
-	if conf.IPFSRevProxyAddr == "" {
-		return nil, nil
-	}
-
-	log.Info("Starting IPFS reverse proxy...")
-	ipfsIP, err := util.TCPAddrFromMultiAddr(conf.IpfsAPIAddr)
-	if err != nil {
-		return nil, fmt.Errorf("converting IPFS multiaddr to tcp addr: %s", err)
-	}
-
-	urlIPFS, err := url.Parse("http://" + ipfsIP)
-	if err != nil {
-		return nil, fmt.Errorf("generating IPFS URL for reverse proxy: %s", err)
-	}
-	rph := httputil.NewSingleHostReverseProxy(urlIPFS)
-	fha := newHTTPFFSAuthInterceptor(rph, m)
-	rp := &http.Server{
-		Addr:    conf.IPFSRevProxyAddr,
-		Handler: fha,
-	}
-
-	go func() {
-		if err := rp.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("serving index http: %v", err)
-		}
-	}()
-	return rp, nil
+func (fha *ffsHTTPAuth) IsIPFSRequest(r *http.Request) bool {
+	return r.URL == fha.url
 }
 
-func createGRPCServer(opts []grpc.ServerOption, webProxyAddr string) (*grpc.Server, *http.Server) {
-	grpcServer := grpc.NewServer(opts...)
+func createProxyServer(wrappedGRPCServer *grpcweb.WrappedGrpcServer, fha *ffsHTTPAuth, webProxyAddr string) *http.Server {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fha.IsIPFSRequest(r) {
+			fha.ServeHTTP(w, r)
+		} else if wrappedGRPCServer.IsGrpcWebRequest(r) ||
+			wrappedGRPCServer.IsAcceptableGrpcCorsRequest(r) ||
+			wrappedGRPCServer.IsGrpcWebSocketRequest(r) {
+			wrappedGRPCServer.ServeHTTP(w, r)
+		}
+	})
+	webProxy := &http.Server{
+		Addr:    webProxyAddr,
+		Handler: handler,
+	}
+	return webProxy
+}
 
+func wrapGRPCServer(grpcServer *grpc.Server) *grpcweb.WrappedGrpcServer {
 	wrappedServer := grpcweb.WrapServer(
 		grpcServer,
 		grpcweb.WithOriginFunc(func(origin string) bool {
@@ -344,18 +345,8 @@ func createGRPCServer(opts []grpc.ServerOption, webProxyAddr string) (*grpc.Serv
 			return true
 		}),
 	)
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if wrappedServer.IsGrpcWebRequest(r) ||
-			wrappedServer.IsAcceptableGrpcCorsRequest(r) ||
-			wrappedServer.IsGrpcWebSocketRequest(r) {
-			wrappedServer.ServeHTTP(w, r)
-		}
-	})
-	grpcWebProxy := &http.Server{
-		Addr:    webProxyAddr,
-		Handler: handler,
-	}
-	return grpcServer, grpcWebProxy
+
+	return wrappedServer
 }
 
 func startGRPCServices(server *grpc.Server, webProxy *http.Server, s *Server, hostNetwork string, hostAddress ma.Multiaddr) error {
@@ -447,14 +438,6 @@ func startIndexHTTPServer(s *Server) *http.Server {
 
 // Close shuts down the server.
 func (s *Server) Close() {
-	if s.ipfsRevProxy != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-		if err := s.ipfsRevProxy.Shutdown(ctx); err != nil {
-			log.Errorf("closing down ipfs reverse proxy: %s", err)
-		}
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -465,7 +448,7 @@ func (s *Server) Close() {
 	log.Info("closing gRPC endpoints...")
 	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := s.grpcWebProxy.Shutdown(ctx); err != nil {
+	if err := s.webProxy.Shutdown(ctx); err != nil {
 		log.Errorf("closing down proxy: %s", err)
 	}
 	stopped := make(chan struct{})

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -278,7 +278,6 @@ func NewServer(conf Config) (*Server, error) {
 type ffsHTTPAuth struct {
 	cont       http.Handler
 	ffsManager *manager.Manager
-	url        *url.URL
 }
 
 func newHTTPFFSAuthInterceptor(conf Config, m *manager.Manager) (*ffsHTTPAuth, error) {
@@ -296,7 +295,6 @@ func newHTTPFFSAuthInterceptor(conf Config, m *manager.Manager) (*ffsHTTPAuth, e
 	fha := &ffsHTTPAuth{
 		cont:       rph,
 		ffsManager: m,
-		url:        urlIPFS,
 	}
 	return fha, nil
 }
@@ -312,7 +310,7 @@ func (fha *ffsHTTPAuth) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 }
 
 func (fha *ffsHTTPAuth) IsIPFSRequest(r *http.Request) bool {
-	return r.URL == fha.url
+	return len(r.Header.Get("x-ipfs-ffs-auth")) > 0
 }
 
 func createProxyServer(wrappedGRPCServer *grpcweb.WrappedGrpcServer, fha *ffsHTTPAuth, webProxyAddr string) *http.Server {

--- a/cli-docs/pow/pow_ffs_get.md
+++ b/cli-docs/pow/pow_ffs_get.md
@@ -13,10 +13,9 @@ pow ffs get [cid] [output file path] [flags]
 ### Options
 
 ```
-  -f, --folder                Indicates that the retrieved Cid is a folder
-  -h, --help                  help for get
-      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6003")
-  -t, --token string          token of the request
+  -f, --folder         Indicates that the retrieved Cid is a folder
+  -h, --help           help for get
+  -t, --token string   token of the request
 ```
 
 ### Options inherited from parent commands

--- a/cli-docs/pow/pow_ffs_get.md
+++ b/cli-docs/pow/pow_ffs_get.md
@@ -15,7 +15,7 @@ pow ffs get [cid] [output file path] [flags]
 ```
   -f, --folder                Indicates that the retrieved Cid is a folder
   -h, --help                  help for get
-      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6003")
+      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6002")
   -t, --token string          token of the request
 ```
 

--- a/cli-docs/pow/pow_ffs_get.md
+++ b/cli-docs/pow/pow_ffs_get.md
@@ -13,9 +13,10 @@ pow ffs get [cid] [output file path] [flags]
 ### Options
 
 ```
-  -f, --folder         Indicates that the retrieved Cid is a folder
-  -h, --help           help for get
-  -t, --token string   token of the request
+  -f, --folder                Indicates that the retrieved Cid is a folder
+  -h, --help                  help for get
+      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6003")
+  -t, --token string          token of the request
 ```
 
 ### Options inherited from parent commands

--- a/cli-docs/pow/pow_ffs_stage.md
+++ b/cli-docs/pow/pow_ffs_stage.md
@@ -13,8 +13,9 @@ pow ffs stage [path] [flags]
 ### Options
 
 ```
-  -h, --help           help for stage
-  -t, --token string   FFS access token
+  -h, --help                  help for stage
+      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6003")
+  -t, --token string          FFS access token
 ```
 
 ### Options inherited from parent commands

--- a/cli-docs/pow/pow_ffs_stage.md
+++ b/cli-docs/pow/pow_ffs_stage.md
@@ -14,7 +14,7 @@ pow ffs stage [path] [flags]
 
 ```
   -h, --help                  help for stage
-      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6003")
+      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6002")
   -t, --token string          FFS access token
 ```
 

--- a/cli-docs/pow/pow_ffs_stage.md
+++ b/cli-docs/pow/pow_ffs_stage.md
@@ -13,9 +13,8 @@ pow ffs stage [path] [flags]
 ### Options
 
 ```
-  -h, --help                  help for stage
-      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6003")
-  -t, --token string          FFS access token
+  -h, --help           help for stage
+  -t, --token string   FFS access token
 ```
 
 ### Options inherited from parent commands

--- a/cmd/pow/cmd/ffs_get.go
+++ b/cmd/pow/cmd/ffs_get.go
@@ -15,6 +15,7 @@ import (
 
 func init() {
 	ffsGetCmd.Flags().StringP("token", "t", "", "token of the request")
+	ffsGetCmd.Flags().String("ipfsrevproxy", "127.0.0.1:6002", "Powergate IPFS reverse proxy multiaddr")
 	ffsGetCmd.Flags().BoolP("folder", "f", false, "Indicates that the retrieved Cid is a folder")
 	ffsCmd.AddCommand(ffsGetCmd)
 }
@@ -43,7 +44,7 @@ var ffsGetCmd = &cobra.Command{
 
 		isFolder := viper.GetBool("folder")
 		if isFolder {
-			err := fcClient.FFS.GetFolder(authCtx(ctx), c, args[1])
+			err := fcClient.FFS.GetFolder(authCtx(ctx), viper.GetString("ipfsrevproxy"), c, args[1])
 			checkErr(err)
 		} else {
 			reader, err := fcClient.FFS.Get(authCtx(ctx), c)

--- a/cmd/pow/cmd/ffs_get.go
+++ b/cmd/pow/cmd/ffs_get.go
@@ -15,7 +15,6 @@ import (
 
 func init() {
 	ffsGetCmd.Flags().StringP("token", "t", "", "token of the request")
-	ffsGetCmd.Flags().String("ipfsrevproxy", "127.0.0.1:6003", "Powergate IPFS reverse proxy multiaddr")
 	ffsGetCmd.Flags().BoolP("folder", "f", false, "Indicates that the retrieved Cid is a folder")
 	ffsCmd.AddCommand(ffsGetCmd)
 }
@@ -44,7 +43,7 @@ var ffsGetCmd = &cobra.Command{
 
 		isFolder := viper.GetBool("folder")
 		if isFolder {
-			err := fcClient.FFS.GetFolder(authCtx(ctx), viper.GetString("ipfsrevproxy"), c, args[1])
+			err := fcClient.FFS.GetFolder(authCtx(ctx), c, args[1])
 			checkErr(err)
 		} else {
 			reader, err := fcClient.FFS.Get(authCtx(ctx), c)

--- a/cmd/pow/cmd/ffs_stage.go
+++ b/cmd/pow/cmd/ffs_stage.go
@@ -16,7 +16,6 @@ import (
 
 func init() {
 	ffsStageCmd.Flags().StringP("token", "t", "", "FFS access token")
-	ffsStageCmd.Flags().String("ipfsrevproxy", "127.0.0.1:6003", "Powergate IPFS reverse proxy multiaddr")
 
 	ffsCmd.AddCommand(ffsStageCmd)
 }
@@ -48,7 +47,7 @@ var ffsStageCmd = &cobra.Command{
 		s := spin.New("%s Staging specified asset in FFS hot storage...")
 		s.Start()
 		if fi.IsDir() {
-			cid, err = fcClient.FFS.StageFolder(authCtx(ctx), viper.GetString("ipfsrevproxy"), args[0])
+			cid, err = fcClient.FFS.StageFolder(authCtx(ctx), args[0])
 			checkErr(err)
 		} else {
 			f, err := os.Open(args[0])

--- a/cmd/pow/cmd/ffs_stage.go
+++ b/cmd/pow/cmd/ffs_stage.go
@@ -16,6 +16,7 @@ import (
 
 func init() {
 	ffsStageCmd.Flags().StringP("token", "t", "", "FFS access token")
+	ffsStageCmd.Flags().String("ipfsrevproxy", "127.0.0.1:6002", "Powergate IPFS reverse proxy multiaddr")
 
 	ffsCmd.AddCommand(ffsStageCmd)
 }
@@ -47,7 +48,7 @@ var ffsStageCmd = &cobra.Command{
 		s := spin.New("%s Staging specified asset in FFS hot storage...")
 		s.Start()
 		if fi.IsDir() {
-			cid, err = fcClient.FFS.StageFolder(authCtx(ctx), args[0])
+			cid, err = fcClient.FFS.StageFolder(authCtx(ctx), viper.GetString("ipfsrevproxy"), args[0])
 			checkErr(err)
 		} else {
 			f, err := os.Open(args[0])

--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -112,7 +112,6 @@ func configFromFlags() (server.Config, error) {
 	ffsUseMasterAddr := config.GetBool("ffsusemasteraddr")
 	grpcWebProxyAddr := config.GetString("grpcwebproxyaddr")
 	gatewayHostAddr := config.GetString("gatewayhostaddr")
-	ipfsRevProxyAddr := config.GetString("ipfsrevproxyaddr")
 	maxminddbfolder := config.GetString("maxminddbfolder")
 
 	return server.Config{
@@ -130,7 +129,6 @@ func configFromFlags() (server.Config, error) {
 		GrpcWebProxyAddress: grpcWebProxyAddr,
 		RepoPath:            repoPath,
 		GatewayHostAddr:     gatewayHostAddr,
-		IPFSRevProxyAddr:    ipfsRevProxyAddr,
 		MaxMindDBFolder:     maxminddbfolder,
 	}, nil
 }
@@ -282,7 +280,6 @@ func setupFlags() error {
 	pflag.String("ipfsapiaddr", "/ip4/127.0.0.1/tcp/5001", "IPFS API endpoint multiaddress. (Optional, only needed if FFS is used)")
 	pflag.Int64("walletinitialfund", 4000000000000000, "FFS initial funding transaction amount in attoFIL received by --lotusmasteraddr. (if set)")
 	pflag.String("gatewayhostaddr", "0.0.0.0:7000", "Gateway host listening address")
-	pflag.String("ipfsrevproxyaddr", "127.0.0.1:6003", "IPFS reverse proxy listen address")
 	pflag.String("maxminddbfolder", ".", "Path of the folder containing GeoLite2-City.mmdb")
 	pflag.Parse()
 

--- a/docker/docker-compose-localnet.yaml
+++ b/docker/docker-compose-localnet.yaml
@@ -17,7 +17,6 @@ services:
       - POWD_DEVNET=true
       - POWD_LOTUSHOST=/dns4/lotus/tcp/7777
       - POWD_IPFSAPIADDR=/dns4/ipfs/tcp/5001
-      - POWD_IPFSREVPROXYADDR=0.0.0.0:6003
     restart: unless-stopped
 
   ipfs:


### PR DESCRIPTION
I combined the gRPC web proxy and the IPFS reverse proxy. Less code to maintain, and for the JS client, the user won't have to provide an "ipfs reverse proxy" argument to construct the client or make calls to `stageFolder` and `getFolder` (it's still necessary in the Go client because the Go gRPC client uses the native gRPC transport which has to listen on a separate address 😞).

Only downside I see is that the reverse proxy is always running on the server now. If we want, we could provide a config flag `bool` that would leave the `ffsHTTPAuth` as `nil` and no proxy handling for IPFS requests would happen in that case.