### PR TITLE
allow ffsusemasteraddr with devnet

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -119,7 +119,7 @@ type Config struct {
 
 // NewServer starts and returns a new server with the given configuration.
 func NewServer(conf Config) (*Server, error) {
-	if conf.FFSUseMasterAddr && !(len(conf.LotusMasterAddr) > 0 || conf.AutocreateMasterAddr) {
+	if conf.FFSUseMasterAddr && !conf.Devnet && !(len(conf.LotusMasterAddr) > 0 || conf.AutocreateMasterAddr) {
 		return nil, fmt.Errorf("FFSUseMasterAddr requires LotusMasterAddr or AutocreateMasterAddr to be provided")
 	}
 


### PR DESCRIPTION
If you run in devenet mode, powergate will create a master address for you. This allows the valid configuration of
```
POWD_DEVNET=true
POWD_FFSUSEMASTERADDR=true
POWD_AUTOCREATEMASTERADDR=false
POWD_LOTUSMASTERADDR=""
```