### PR TITLE
support nerpa

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -44,3 +44,24 @@ calibration-down:
 		-f powergate-build-context.yaml \
 		down
 .PHONY: calibration-down
+
+
+nerpa-up: nerpa-down
+	LOTUS_IMAGE_TAG=nerpa-53c7594 \
+	docker-compose \
+		-p nerpa \
+		-f docker-compose.yaml \
+		-f ipfs-image.yaml \
+		-f powergate-build-context.yaml \
+		up --build 
+.PHONY: nerpa-up
+
+nerpa-down:
+	LOTUS_IMAGE_TAG=nerpa-53c7594 \
+	docker-compose \
+		-p nerpa \
+		-f docker-compose.yaml \
+		-f ipfs-image.yaml \
+		-f powergate-build-context.yaml \
+		down
+.PHONY: nerpa-down

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
-COMPAT_MSG="The current version of Powergate support newer versions than Testnet network. You might be interested in using the Calibration network (make calibration-up)"
+COMPAT_MSG="The current version of Powergate support newer versions than Testnet network. You might be interested in using the Calibration network (make calibration-up) or Nerpa network (make nerpa-up)."
 
 down:
 	@echo ${COMPAT_MSG}

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,6 +22,7 @@ services:
       - POWD_IPFSAPIADDR=/dns4/ipfs/tcp/5001
       - POWD_LOTUSTOKENFILE=/root/lotus/.lotus/token
       - POWD_REPOPATH=/root/powergate/.powergate
+      - POWD_AUTOCREATEMASTERADDR=true
     restart: unless-stopped
     volumes:
       - powergate-powd:/root/powergate

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -22,7 +22,6 @@ services:
       - POWD_IPFSAPIADDR=/dns4/ipfs/tcp/5001
       - POWD_LOTUSTOKENFILE=/root/lotus/.lotus/token
       - POWD_REPOPATH=/root/powergate/.powergate
-      - POWD_AUTOCREATEMASTERADDR=true
     restart: unless-stopped
     volumes:
       - powergate-powd:/root/powergate

--- a/fchost/config.go
+++ b/fchost/config.go
@@ -17,6 +17,12 @@ var (
 			"/dns4/bootstrap-2.calibration.fildev.network/tcp/1347/p2p/12D3KooWBM8Zdq288tyYF5yT1j2ym9ynApddGJFjYnXNiFiCbdXp",
 			"/dns4/bootstrap-3.calibration.fildev.network/tcp/1347/p2p/12D3KooWKoegjZRfgY8Zp6QMqr4UtuJHzTKeWVmrniFNXeikzvGT",
 		},
+		"nerpanet": {
+			"/dns4/bootstrap-0.nerpa.interplanetary.dev/tcp/1347/p2p/12D3KooWECgvrrRRHpSGmrdLmi8m2JFm7FUvvfcrQxL1rMgN5DEd",
+			"/dns4/bootstrap-1.nerpa.interplanetary.dev/tcp/1347/p2p/12D3KooWSQ9iAaZvQvLHytgygVxo2GNXY6tXvPLtD7GSEqG6Vqya",
+			"/dns4/bootstrap-2.nerpa.interplanetary.dev/tcp/1347/p2p/12D3KooWMfFW7tswrVhhWC89MkgZQfsVGDMEazSp7YTeu2Hh8n8y",
+			"/dns4/bootstrap-3.nerpa.interplanetary.dev/tcp/1347/p2p/12D3KooWAGUEc5QWMjqvLYVsT5Rh7LgXvUcLc6xgyfkSuYMoEBdb",
+		},
 	}
 )
 

--- a/wallet/module/wallet.go
+++ b/wallet/module/wallet.go
@@ -21,7 +21,7 @@ var (
 
 	networkFaucet = map[string]string{
 		"testnet":  "https://faucet.testnet.filecoin.io",
-		"nerpanet": "https://faucet.nerpa.fildev.network",
+		"nerpanet": "https://faucet.nerpa.interplanetary.dev",
 	}
 )
 


### PR DESCRIPTION
Adds support for `ntwk-nerpa` with `make nerpa-up`.
This network supports `POWD_AUTOCREATEMASTERADDR=true`.

I took a look at the commit history of `ntwk-nerpa` and is almost at the same level that we our `ntwk-calibration` support, so all should work fine. 

I ran `make nerpa-up` locally and all things look good. Unfortunately, the network doesn't have any miner replying Storage Asks, so maybe tomorrow there might be some.