### PR TITLE
--enable-pubsub-experiement in ipfs-image.yaml

### DIFF
--- a/docker/ipfs-image.yaml
+++ b/docker/ipfs-image.yaml
@@ -4,3 +4,4 @@ services:
 
   ipfs:
     image: ipfs/go-ipfs:v0.6.0
+    command: ["daemon", "--migrate=true", "--enable-pubsub-experiment"]


### PR DESCRIPTION
Similar to #574 but a more minimal change. I'm working on https://github.com/orbitdb/orbit-db-powergate-io and OrbitDB requires pubsub for DB replication.