### PR TITLE
fix revproxy client scheme

### DIFF
--- a/api/client/ffs.go
+++ b/api/client/ffs.go
@@ -812,10 +812,10 @@ func newDecoratedIPFSAPI(proxyAddr, ffsToken string) (*httpapi.HttpApi, error) {
 	if err != nil {
 		return nil, err
 	}
-	useHTTPs := ipport[1] == "443"
+	useHTTPS := ipport[1] == "443"
 	ipfsMaddr := cm.Encapsulate(cp)
 	customClient := http.DefaultClient
-	customClient.Transport = newFFSHeaderDecorator(ffsToken, useHTTPs)
+	customClient.Transport = newFFSHeaderDecorator(ffsToken, useHTTPS)
 	ipfs, err := httpapi.NewApiWithClient(ipfsMaddr, customClient)
 	if err != nil {
 		return nil, err
@@ -825,19 +825,19 @@ func newDecoratedIPFSAPI(proxyAddr, ffsToken string) (*httpapi.HttpApi, error) {
 
 type ffsHeaderDecorator struct {
 	ffsToken string
-	useHTTPs bool
+	useHTTPS bool
 }
 
-func newFFSHeaderDecorator(ffsToken string, useHTTPs bool) *ffsHeaderDecorator {
+func newFFSHeaderDecorator(ffsToken string, useHTTPS bool) *ffsHeaderDecorator {
 	return &ffsHeaderDecorator{
 		ffsToken: ffsToken,
-		useHTTPs: useHTTPs,
+		useHTTPS: useHTTPS,
 	}
 }
 
 func (fhd ffsHeaderDecorator) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header["x-ipfs-ffs-auth"] = []string{fhd.ffsToken}
-	if fhd.useHTTPs {
+	if fhd.useHTTPS {
 		req.URL.Scheme = "https"
 	}
 

--- a/cli-docs/pow/pow_ffs_get.md
+++ b/cli-docs/pow/pow_ffs_get.md
@@ -15,7 +15,7 @@ pow ffs get [cid] [output file path] [flags]
 ```
   -f, --folder                Indicates that the retrieved Cid is a folder
   -h, --help                  help for get
-      --ipfsrevproxy string   Powergate IPFS reverse proxy multiaddr (default "127.0.0.1:6002")
+      --ipfsrevproxy string   Powergate IPFS reverse proxy DNS address. If port 443, is assumed is a HTTPS endpoint. (default "localhost:6002")
   -t, --token string          token of the request
 ```
 

--- a/cmd/pow/cmd/ffs_get.go
+++ b/cmd/pow/cmd/ffs_get.go
@@ -15,7 +15,7 @@ import (
 
 func init() {
 	ffsGetCmd.Flags().StringP("token", "t", "", "token of the request")
-	ffsGetCmd.Flags().String("ipfsrevproxy", "127.0.0.1:6002", "Powergate IPFS reverse proxy multiaddr")
+	ffsGetCmd.Flags().String("ipfsrevproxy", "localhost:6002", "Powergate IPFS reverse proxy DNS address. If port 443, is assumed is a HTTPS endpoint.")
 	ffsGetCmd.Flags().BoolP("folder", "f", false, "Indicates that the retrieved Cid is a folder")
 	ffsCmd.AddCommand(ffsGetCmd)
 }


### PR DESCRIPTION
The previous setup of `--ipfsrevproxy` wasn't aware of HTTPS endpoints.

The ideal solution with would be constructing a `/dns4/dnsoftheendpoint/tcp/443/https`, but the  IPFS HTTPS client seems to ignore that last `/https` indication of the right protocol to use, so it always use HTTP.

I took advantage of our interceptor that set the `x-ipfs-ffs-auth` to solve the URL scheme appropriately.