### PR TITLE
Decrease indexing load & fail in unknown Jobs

### DIFF
--- a/ffs/api/api_jobs.go
+++ b/ffs/api/api_jobs.go
@@ -16,7 +16,7 @@ func (i *API) WatchJobs(ctx context.Context, c chan<- ffs.Job, jids ...ffs.JobID
 	for _, jid := range jids {
 		j, err := i.sched.GetJob(jid)
 		if err == scheduler.ErrNotFound {
-			continue
+			return fmt.Errorf("job not found: %s", jid)
 		}
 		if err != nil {
 			return fmt.Errorf("getting current job state: %s", err)

--- a/index/ask/runner/runner.go
+++ b/index/ask/runner/runner.go
@@ -22,9 +22,9 @@ import (
 )
 
 var (
-	qaRatelim         = 20
+	qaRatelim         = 5
 	qaTimeout         = time.Second * 20
-	qaRefreshInterval = 15 * time.Minute
+	qaRefreshInterval = 30 * time.Minute
 
 	log = logging.Logger("index-ask")
 )

--- a/index/faults/module/faults.go
+++ b/index/faults/module/faults.go
@@ -123,9 +123,6 @@ func (s *Index) Close() error {
 // start is a long running job that keeps the index up to date with chain updates.
 func (s *Index) start() {
 	defer close(s.finished)
-	if err := s.updateIndex(); err != nil {
-		log.Errorf("initial updating faults index: %s", err)
-	}
 	for {
 		select {
 		case <-s.ctx.Done():

--- a/index/miner/module/miner.go
+++ b/index/miner/module/miner.go
@@ -25,7 +25,7 @@ const (
 
 var (
 	minersRefreshInterval = time.Minute * 30
-	maxParallelism        = 10
+	maxParallelism        = 1
 	dsBase                = datastore.NewKey("index")
 
 	log = logging.Logger("index-miner")
@@ -159,7 +159,7 @@ func (mi *Index) start() {
 	defer func() { mi.finished <- struct{}{} }()
 
 	if err := mi.updateOnChainIndex(); err != nil {
-		log.Errorf("error on initial updating miner index: %s", err)
+		log.Errorf("initial updating miner index: %s", err)
 	}
 	mi.chMeta <- struct{}{}
 	for {
@@ -175,7 +175,7 @@ func (mi *Index) start() {
 			}
 		case <-mi.minerTicker.C:
 			if err := mi.updateOnChainIndex(); err != nil {
-				log.Errorf("error when updating miner index: %s", err)
+				log.Errorf("updating miner index: %s", err)
 				continue
 			}
 		}


### PR DESCRIPTION
In short:
- Decrease concurrency while building the indexes. I want to be as sure as possible the sync process isn't messed up.
- If we get a `WatchJobs` API call with unknown Jobs, fail fast. In theory this shouldn't be a problem, but now considering a situation where the Hub could ask for Jobs from a previous (reset) Powergate instance, we want to give a clear indication that we don't have a clue of those Jobs anymore. (See https://github.com/textileio/textile/pull/330)