### PR TITLE
support urls in ffs stage command

### DIFF
--- a/cli-docs/pow/pow_ffs_stage.md
+++ b/cli-docs/pow/pow_ffs_stage.md
@@ -7,7 +7,7 @@ Temporarily stage data in the Hot layer in preparation for pushing a cid storage
 Temporarily stage data in the Hot layer in preparation for pushing a cid storage config
 
 ```
-pow ffs stage [path] [flags]
+pow ffs stage [path|url] [flags]
 ```
 
 ### Options


### PR DESCRIPTION
this makes `pow ffs stage https://url-to-file` work, expanding the potential sources for staging into powergate. I've smoke-tested with a 250Mb file stored in an S3 bucket, can confirm it's very nice to have.

Urls *only* write to files (no folder support), which I think covers most url-oriented use-cases.

One caveat: if a user has a file that starts with 'http', it'll be a problem. The easiest fix is to refer to the file with a `./` prefix, such as: `./http`