### PR TITLE
force reputation minerselector in localnet

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -536,6 +536,9 @@ func createDatastore(conf Config) (datastore.TxnDatastore, error) {
 }
 
 func getMinerSelector(conf Config, rm *reputation.Module, ai *ask.Runner, cb lotus.ClientBuilder) (ffs.MinerSelector, error) {
+	if conf.Devnet {
+		return reptop.New(rm, ai), nil
+	}
 	var ms ffs.MinerSelector
 	var err error
 


### PR DESCRIPTION
Force using the `reputation` miner-selector, instead of the default one (now SR2), when running in localnet mode.