### PR TITLE
Use configured deal timeout for storage deal monitoring

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -212,7 +212,7 @@ func NewServer(conf Config) (*Server, error) {
 	if conf.Devnet {
 		conf.DealWatchPollDuration = time.Second
 	}
-	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), clientBuilder, conf.DealWatchPollDuration, deals.WithImportPath(filepath.Join(conf.RepoPath, "imports")))
+	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), clientBuilder, conf.DealWatchPollDuration, conf.FFSDealFinalityTimeout, deals.WithImportPath(filepath.Join(conf.RepoPath, "imports")))
 	if err != nil {
 		return nil, fmt.Errorf("creating deal module: %s", err)
 	}

--- a/deals/module/deals_test.go
+++ b/deals/module/deals_test.go
@@ -49,7 +49,7 @@ func TestStore(t *testing.T) {
 			t.Parallel()
 			tests.RunFlaky(t, func(t *tests.FlakyT) {
 				clientBuilder, addr, _ := tests.CreateLocalDevnet(t, nm)
-				m, err := New(tests.NewTxMapDatastore(), clientBuilder, util.AvgBlockTime, deals.WithImportPath(filepath.Join(tmpDir, "imports")))
+				m, err := New(tests.NewTxMapDatastore(), clientBuilder, util.AvgBlockTime, time.Minute*10, deals.WithImportPath(filepath.Join(tmpDir, "imports")))
 				require.NoError(t, err)
 				c, cls, err := clientBuilder()
 				require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestRetrieve(t *testing.T) {
 			tests.RunFlaky(t, func(t *tests.FlakyT) {
 				data := randomBytes(600)
 				clientBuilder, addr, _ := tests.CreateLocalDevnet(t, nm)
-				m, err := New(tests.NewTxMapDatastore(), clientBuilder, util.AvgBlockTime, deals.WithImportPath(filepath.Join(tmpDir, "imports")))
+				m, err := New(tests.NewTxMapDatastore(), clientBuilder, util.AvgBlockTime, time.Minute*10, deals.WithImportPath(filepath.Join(tmpDir, "imports")))
 				require.NoError(t, err)
 				c, cls, err := clientBuilder()
 				require.NoError(t, err)

--- a/ffs/integrationtest/integrationtest.go
+++ b/ffs/integrationtest/integrationtest.go
@@ -134,7 +134,7 @@ func NewFFSManager(t require.TestingT, ds datastore.TxnDatastore, clientBuilder 
 
 // NewCustomFFSManager returns a new customized FFS manager.
 func NewCustomFFSManager(t require.TestingT, ds datastore.TxnDatastore, clientBuilder lotus.ClientBuilder, masterAddr address.Address, ms ffs.MinerSelector, ipfsClient *httpapi.HttpApi, minimumPieceSize uint64) (*manager.Manager, func()) {
-	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), clientBuilder, util.AvgBlockTime)
+	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), clientBuilder, time.Minute*10, util.AvgBlockTime)
 	require.NoError(t, err)
 
 	fchain := filchain.New(clientBuilder)

--- a/ffs/integrationtest/integrationtest.go
+++ b/ffs/integrationtest/integrationtest.go
@@ -134,7 +134,7 @@ func NewFFSManager(t require.TestingT, ds datastore.TxnDatastore, clientBuilder 
 
 // NewCustomFFSManager returns a new customized FFS manager.
 func NewCustomFFSManager(t require.TestingT, ds datastore.TxnDatastore, clientBuilder lotus.ClientBuilder, masterAddr address.Address, ms ffs.MinerSelector, ipfsClient *httpapi.HttpApi, minimumPieceSize uint64) (*manager.Manager, func()) {
-	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), clientBuilder, time.Minute*10, util.AvgBlockTime)
+	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), clientBuilder, util.AvgBlockTime, time.Minute*10)
 	require.NoError(t, err)
 
 	fchain := filchain.New(clientBuilder)

--- a/ffs/manager/manager_test.go
+++ b/ffs/manager/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/filecoin-project/go-address"
 	"github.com/ipfs/go-datastore"
@@ -199,7 +200,7 @@ func newManager(clientBuilder lotus.ClientBuilder, ds datastore.TxnDatastore, ma
 		return nil, func() error { return nil }, err
 	}
 	pm := paych.New(clientBuilder)
-	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), clientBuilder, util.AvgBlockTime)
+	dm, err := dealsModule.New(txndstr.Wrap(ds, "deals"), clientBuilder, util.AvgBlockTime, time.Minute*10)
 	if err != nil {
 		return nil, func() error { return nil }, err
 	}


### PR DESCRIPTION
Pretty self explanatory. The previous 24hr timeout was too short.

fixes #676 