### PR TITLE
Fix ShowAll to ignore ErrNotFound

### DIFF
--- a/cmd/pow/cmd/ffs_show.go
+++ b/cmd/pow/cmd/ffs_show.go
@@ -2,13 +2,13 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"github.com/caarlos0/spin"
 	"github.com/ipfs/go-cid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -35,21 +35,18 @@ var ffsShowCmd = &cobra.Command{
 		if len(args) == 1 {
 			c, err := cid.Parse(args[0])
 			checkErr(err)
-			s := spin.New("%s Getting info for cid...")
-			s.Start()
 			res, err = fcClient.FFS.Show(authCtx(ctx), c)
-			s.Stop()
 			checkErr(err)
 
 		} else {
-			s := spin.New("%s Getting info all stored cids...")
-			s.Start()
 			var err error
 			res, err = fcClient.FFS.ShowAll(authCtx(ctx))
-			s.Stop()
 			checkErr(err)
 		}
 
-		Success("\n%v", prototext.Format(res))
+		json, err := protojson.MarshalOptions{Multiline: true, Indent: "  "}.Marshal(res)
+		checkErr(err)
+
+		fmt.Println(string(json))
 	},
 }

--- a/ffs/rpc/rpc.go
+++ b/ffs/rpc/rpc.go
@@ -609,6 +609,9 @@ func (s *RPC) ShowAll(ctx context.Context, req *ShowAllRequest) (*ShowAllRespons
 	cidInfos := make([]*CidInfo, len(instanceInfo.Pins))
 	for j, cid := range instanceInfo.Pins {
 		cidInfo, err := i.Show(cid)
+		if err == api.ErrNotFound {
+			continue
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is the correct behavior for a "find all" kind of API. This will also allow teams another way to reliably get a list of all deal information for slingshot. Results look like:
```
{
  "cidInfos":  [
    {
      "jobId":  "9b6fbda3-c002-45b0-b68c-69df8e6a576c",
      "cid":  "QmQJxVtp61Y7UrdjUKuWvse3TxGHaPDyA7RobrBhFwqcBM",
      "created":  "1602799361752777400",
      "hot":  {
        "enabled":  true,
        "size":  "83156098",
        "ipfs":  {
          "created":  "1602799272524365700"
        }
      },
      "cold":  {
        "enabled":  true,
        "filecoin":  {
          "dataCid":  "QmQJxVtp61Y7UrdjUKuWvse3TxGHaPDyA7RobrBhFwqcBM",
          "size":  "134217728",
          "proposals":  [
            {
              "proposalCid":  "bafyreifq2zge7qbqqudce7purihozcnpbn75bb5wzxgukrw5vryim5nif4",
              "duration":  "521330",
              "activationEpoch":  "890",
              "startEpoch":  "9247",
              "miner":  "f01000",
              "epochPrice":  "62500000",
              "pieceCid":  "baga6ea4seaqadg3evy6wzm5qksy6d3zyfsoh7ci7gcoasut76fxpyh77nxsk6cy"
            }
          ]
        }
      }
    }
  ]
}
```