### PR TITLE
update go-ds-mongo and account for errors in queries

### DIFF
--- a/deals/module/deals.go
+++ b/deals/module/deals.go
@@ -307,6 +307,7 @@ func (m *Module) GetDealStatus(ctx context.Context, pcid cid.Cid) (storagemarket
 		return storagemarket.StorageDealUnknown, false, fmt.Errorf("creating lotus client: %s", err)
 	}
 	defer cls()
+	now := time.Now()
 	di, err := lapi.ClientGetDealInfo(ctx, pcid)
 	if err != nil {
 		if strings.Contains(err.Error(), "datastore: key not found") {
@@ -314,11 +315,8 @@ func (m *Module) GetDealStatus(ctx context.Context, pcid cid.Cid) (storagemarket
 		}
 		return storagemarket.StorageDealUnknown, false, fmt.Errorf("getting deal info: %s", err)
 	}
-	md, err := lapi.StateMarketStorageDeal(ctx, di.DealID, types.EmptyTSK)
-	if err != nil {
-		return storagemarket.StorageDealUnknown, false, fmt.Errorf("get storage state: %s", err)
-	}
-	return di.State, md.State.SlashEpoch != -1, nil
+	log.Infof("GetDealStatus(): %dms", time.Since(now).Milliseconds())
+	return di.State, di.State == storagemarket.StorageDealSlashed, nil
 }
 
 // Watch returns a channel with state changes of indicated proposals.
@@ -618,10 +616,12 @@ func (m *Module) recordRetrieval(addr string, offer api.QueryOffer) {
 
 func notifyChanges(ctx context.Context, client *apistruct.FullNodeStruct, currState map[cid.Cid]*api.DealInfo, proposals []cid.Cid, ch chan<- deals.StorageDealInfo) error {
 	for _, pcid := range proposals {
+		now := time.Now()
 		dinfo, err := client.ClientGetDealInfo(ctx, pcid)
 		if err != nil {
 			return fmt.Errorf("getting deal proposal info %s: %s", pcid, err)
 		}
+		log.Infof("client get deal info call: %d", time.Since(now).Milliseconds())
 		if currState[pcid] == nil || (*currState[pcid]).State != dinfo.State {
 			currState[pcid] = dinfo
 			newState, err := fromLotusDealInfo(ctx, client, dinfo)

--- a/deals/module/store.go
+++ b/deals/module/store.go
@@ -72,6 +72,9 @@ func (s *store) getPendingDeals() ([]deals.StorageDealRecord, error) {
 
 	var ret []deals.StorageDealRecord
 	for r := range res.Next() {
+		if r.Error != nil {
+			return nil, fmt.Errorf("iter next: %s", r.Error)
+		}
 		var dr deals.StorageDealRecord
 		if err := json.Unmarshal(r.Value, &dr); err != nil {
 			return nil, fmt.Errorf("unmarshaling query result: %s", err)
@@ -114,6 +117,9 @@ func (s *store) getFinalDeals() ([]deals.StorageDealRecord, error) {
 
 	var ret []deals.StorageDealRecord
 	for r := range res.Next() {
+		if r.Error != nil {
+			return nil, fmt.Errorf("iter next: %s", r.Error)
+		}
 		var dealRecord deals.StorageDealRecord
 		if err := json.Unmarshal(r.Value, &dealRecord); err != nil {
 			return nil, fmt.Errorf("unmarshaling query result: %s", err)
@@ -152,6 +158,9 @@ func (s *store) getRetrievals() ([]deals.RetrievalDealRecord, error) {
 
 	var ret []deals.RetrievalDealRecord
 	for r := range res.Next() {
+		if r.Error != nil {
+			return nil, fmt.Errorf("iter next: %s", r.Error)
+		}
 		var rr deals.RetrievalDealRecord
 		if err := json.Unmarshal(r.Value, &rr); err != nil {
 			return nil, fmt.Errorf("unmarshaling query result: %s", err)

--- a/ffs/api/istore.go
+++ b/ffs/api/istore.go
@@ -118,7 +118,7 @@ func (s *instanceStore) getCids() ([]cid.Cid, error) {
 
 	var cids []cid.Cid
 	for r := range res.Next() {
-		if err != nil {
+		if r.Error != nil {
 			return nil, fmt.Errorf("iter next: %s", r.Error)
 		}
 		strCid := datastore.RawKey(r.Key).Name()

--- a/ffs/api/istore.go
+++ b/ffs/api/istore.go
@@ -118,6 +118,9 @@ func (s *instanceStore) getCids() ([]cid.Cid, error) {
 
 	var cids []cid.Cid
 	for r := range res.Next() {
+		if err != nil {
+			return nil, fmt.Errorf("iter next: %s", r.Error)
+		}
 		strCid := datastore.RawKey(r.Key).Name()
 		c, err := util.CidFromString(strCid)
 		if err != nil {

--- a/ffs/auth/auth.go
+++ b/ffs/auth/auth.go
@@ -95,6 +95,9 @@ func (r *Auth) List() ([]ffs.APIID, error) {
 
 	var ret []ffs.APIID
 	for r := range res.Next() {
+		if r.Error != nil {
+			return nil, fmt.Errorf("iter next: %s", r.Error)
+		}
 		var e entry
 		if err := json.Unmarshal(r.Entry.Value, &e); err != nil {
 			return nil, fmt.Errorf("unmarshaling query result: %s", err)

--- a/ffs/filcold/filcold.go
+++ b/ffs/filcold/filcold.go
@@ -331,8 +331,6 @@ Loop:
 // padding. It's important to not underestimate the size since that would lead to deal rejection
 // since the miner won't accept the further calculated PricePerEpoch.
 func (fc *FilCold) calculatePieceSize(ctx context.Context, c cid.Cid) (uint64, error) {
-	ctx, cls := context.WithTimeout(ctx, time.Minute*15)
-	defer cls()
 	// Get unique nodes.
 	seen := cid.NewSet()
 	if err := dag.Walk(ctx, fc.getLinks, c, seen.Visit); err != nil {

--- a/ffs/filcold/filcold.go
+++ b/ffs/filcold/filcold.go
@@ -331,6 +331,8 @@ Loop:
 // padding. It's important to not underestimate the size since that would lead to deal rejection
 // since the miner won't accept the further calculated PricePerEpoch.
 func (fc *FilCold) calculatePieceSize(ctx context.Context, c cid.Cid) (uint64, error) {
+	ctx, cls := context.WithTimeout(ctx, time.Minute*15)
+	defer cls()
 	// Get unique nodes.
 	seen := cid.NewSet()
 	if err := dag.Walk(ctx, fc.getLinks, c, seen.Visit); err != nil {

--- a/ffs/joblogger/joblogger.go
+++ b/ffs/joblogger/joblogger.go
@@ -108,6 +108,9 @@ func (cl *Logger) GetByCid(ctx context.Context, c cid.Cid) ([]ffs.LogEntry, erro
 	}()
 	var lgs []ffs.LogEntry
 	for r := range res.Next() {
+		if r.Error != nil {
+			return nil, fmt.Errorf("iter next: %s", r.Error)
+		}
 		var le logEntry
 		if err := json.Unmarshal(r.Value, &le); err != nil {
 			return nil, fmt.Errorf("unmarshaling log entry: %s", err)

--- a/ffs/scheduler/internal/rjstore/rjstore.go
+++ b/ffs/scheduler/internal/rjstore/rjstore.go
@@ -83,6 +83,9 @@ func (s *Store) Dequeue() (*ffs.RetrievalJob, error) {
 		}
 	}()
 	for r := range res.Next() {
+		if r.Error != nil {
+			return nil, fmt.Errorf("iter next: %s", r.Error)
+		}
 		var j ffs.RetrievalJob
 		if err := json.Unmarshal(r.Value, &j); err != nil {
 			return nil, fmt.Errorf("unmarshalling job: %s", err)

--- a/ffs/scheduler/internal/sjstore/sjstore.go
+++ b/ffs/scheduler/internal/sjstore/sjstore.go
@@ -174,6 +174,9 @@ func (s *Store) cancelQueued(c cid.Cid) error {
 		}
 	}()
 	for r := range res.Next() {
+		if r.Error != nil {
+			return fmt.Errorf("iter next: %s", r.Error)
+		}
 		var j ffs.StorageJob
 		if err := json.Unmarshal(r.Value, &j); err != nil {
 			return fmt.Errorf("unmarshalling job: %s", err)
@@ -378,6 +381,9 @@ func (s *Store) loadExecutingJobs() error {
 		}
 	}()
 	for r := range res.Next() {
+		if r.Error != nil {
+			return fmt.Errorf("iter next: %s", r.Error)
+		}
 		var j ffs.StorageJob
 		if err := json.Unmarshal(r.Value, &j); err != nil {
 			return fmt.Errorf("unmarshalling job: %s", err)
@@ -404,6 +410,9 @@ func (s *Store) loadQueuedJobs() error {
 		}
 	}()
 	for r := range res.Next() {
+		if r.Error != nil {
+			return fmt.Errorf("iter next: %s", r.Error)
+		}
 		var j ffs.StorageJob
 		if err := json.Unmarshal(r.Value, &j); err != nil {
 			return fmt.Errorf("unmarshalling job: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.6.1
-	github.com/textileio/go-ds-mongo v0.1.0
+	github.com/textileio/go-ds-mongo v0.1.2
 	go.opencensus.io v0.22.4
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	google.golang.org/grpc v1.32.0

--- a/go.sum
+++ b/go.sum
@@ -337,7 +337,6 @@ github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmC
 github.com/gin-gonic/gin v1.6.3 h1:ahKqKTFpO5KTPHxWZjEdPScmYaGtLo8Y4DMHoEsnp14=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
-github.com/go-check/check v0.0.0-20180628173108-788fd7840127 h1:0gkP6mzaMqkmpcJYCFOLkIBwI7xFExG03bbkOkCvUPI=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -603,12 +602,10 @@ github.com/ipfs/go-datastore v0.0.5/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAK
 github.com/ipfs/go-datastore v0.1.0/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=
 github.com/ipfs/go-datastore v0.1.1/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
 github.com/ipfs/go-datastore v0.3.0/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
-github.com/ipfs/go-datastore v0.3.1 h1:SS1t869a6cctoSYmZXUk8eL6AzVXgASmKIWFNQkQ1jU=
 github.com/ipfs/go-datastore v0.3.1/go.mod h1:w38XXW9kVFNp57Zj5knbKWM2T+KOZCGDRVNdgPHtbHw=
 github.com/ipfs/go-datastore v0.4.0/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
 github.com/ipfs/go-datastore v0.4.1/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
 github.com/ipfs/go-datastore v0.4.2/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
-github.com/ipfs/go-datastore v0.4.4 h1:rjvQ9+muFaJ+QZ7dN5B1MSDNQ0JVZKkkES/rMZmA8X8=
 github.com/ipfs/go-datastore v0.4.4/go.mod h1:SX/xMIKoCszPqp+z9JhPYCmoOoXTvaa13XEbGtsFUhA=
 github.com/ipfs/go-datastore v0.4.5 h1:cwOUcGMLdLPWgu3SlrCckCMznaGADbPqE0r8h768/Dg=
 github.com/ipfs/go-datastore v0.4.5/go.mod h1:eXTcaaiN6uOlVCLS9GjJUJtlvJfM3xk23w3fyfrmmJs=
@@ -1683,8 +1680,8 @@ github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpP
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/textileio/go-datastore-extensions v1.0.0 h1:afpl9qlS1PUdYS9uj1cXTStj6BbzeSQSRscggTE4V0c=
 github.com/textileio/go-datastore-extensions v1.0.0/go.mod h1:Pzj9FDRkb55910dr/FX8M7WywvnS26gBgEDez1ZBuLE=
-github.com/textileio/go-ds-mongo v0.1.0 h1:aZrsVQ1R52x65Zv6QsH3kM1bnR3oyVzEuAjCwZ63GkE=
-github.com/textileio/go-ds-mongo v0.1.0/go.mod h1:9wmGTUr+MWidGxYQe27RuCogEUZ7vnQxZb4GWj7uWL8=
+github.com/textileio/go-ds-mongo v0.1.2 h1:sL7wFBfETdn18lmLqc7wVOFcn9Yy7lqNqFqQQAeB6hU=
+github.com/textileio/go-ds-mongo v0.1.2/go.mod h1:9wmGTUr+MWidGxYQe27RuCogEUZ7vnQxZb4GWj7uWL8=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/reputation/internal/source/store.go
+++ b/reputation/internal/source/store.go
@@ -3,6 +3,7 @@ package source
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/query"
@@ -87,6 +88,9 @@ func (ss *Store) GetAll() ([]Source, error) {
 	}()
 	var ret []Source
 	for r := range res.Next() {
+		if r.Error != nil {
+			return nil, fmt.Errorf("iter next: %s", r.Error)
+		}
 		s := Source{}
 		if err := json.Unmarshal(r.Value, &s); err != nil {
 			return nil, err

--- a/tests/txmapds.go
+++ b/tests/txmapds.go
@@ -65,6 +65,9 @@ func (d *TxMapDatastore) Clone() (*TxMapDatastore, error) {
 		MapDatastore: datastore.NewMapDatastore(),
 	}
 	for v := range res.Next() {
+		if v.Error != nil {
+			return nil, fmt.Errorf("iter next: %s", v.Error)
+		}
 		if err := t2.Put(datastore.NewKey(v.Key), v.Value); err != nil {
 			return nil, fmt.Errorf("copying datastore value: %s", err)
 		}


### PR DESCRIPTION
Updates `go-ds-mongo` version which has bug fixes which caused panics in very unlucky situations of where the MongoDB database timeout.

Also, account for checking always errors in queries!