### PR TITLE
Fix canceling retry

### DIFF
--- a/ffs/integrationtest/scheduler/scheduler_test.go
+++ b/ffs/integrationtest/scheduler/scheduler_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func TestJobCancellation(t *testing.T) {
+func TestJobCancelation(t *testing.T) {
 	r := rand.New(rand.NewSource(22))
 	ipfsAPI, _, fapi, cls := it.NewAPI(t, 1)
 	defer cls()

--- a/ffs/scheduler/scheduler.go
+++ b/ffs/scheduler/scheduler.go
@@ -407,11 +407,17 @@ func (s *Scheduler) executeQueuedStorage(j ffs.StorageJob) {
 	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), ffs.CtxKeyJid, j.ID))
 	defer cancel()
 	ctx = context.WithValue(ctx, ffs.CtxStorageCid, j.Cid)
+
+	var cancelLock sync.Mutex
+	var canceled bool
 	go func() {
 		// If the user called Cancel to cancel Job execution,
 		// we cancel the context to finish.
 		<-cancelChan
 		cancel()
+		cancelLock.Lock()
+		canceled = true
+		cancelLock.Unlock()
 	}()
 
 	// Get
@@ -446,11 +452,11 @@ func (s *Scheduler) executeQueuedStorage(j ffs.StorageJob) {
 
 	finalStatus := ffs.Success
 	// Detect if user-cancelation was triggered
-	select {
-	case <-cancelChan:
+	cancelLock.Lock()
+	if canceled {
 		finalStatus = ffs.Canceled
-	default:
 	}
+	cancelLock.Unlock()
 
 	// Finalize Job, saving any deals errors happened during execution.
 	if err := s.sjs.Finalize(j.ID, finalStatus, nil, dealErrors); err != nil {


### PR DESCRIPTION
Canceling an executing Job was done by closing a cancel channel. This isn't nice to handle the case of the user retrying canceling multiple times without extra logic.

Switch to pushing a value to the channel, and just not blocking on retries.