### PR TITLE
gateway: fix epoch to date

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: golangci/golangci-lint-action@v1
+      - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.27
+          version: v1.29
   spell-check:
      name: spell-check
      runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.1-buster as builder
+FROM golang:1.15.5-buster as builder
 
 RUN mkdir /app 
 WORKDIR /app 

--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -366,7 +366,7 @@ func setupFlags() error {
 	pflag.String("dealwatchpollduration", "900", "Poll interval in seconds used by Deals Module watch to detect state changes")
 
 	pflag.String("askindexqueryasktimeout", "15", "Timeout in seconds for a query ask")
-	pflag.String("askindexrefreshinterval", "60", "Refresh interval measured in minutes")
+	pflag.String("askindexrefreshinterval", "360", "Refresh interval measured in minutes")
 	pflag.Bool("askindexrefreshonstart", false, "If true it will refresh the index on start")
 	pflag.String("askindexmaxparallel", "3", "Max parallel query ask to execute while updating index")
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -198,7 +198,7 @@ func (g *Gateway) minersHandler(c *gin.Context) {
 		i++
 	}
 
-	chainSubtitle := fmt.Sprintf("Last updated %v", timeToString(uint64ToTime(index.OnChain.LastUpdated)))
+	chainSubtitle := fmt.Sprintf("Last updated %v", timeToString(epochToTime(index.OnChain.LastUpdated)))
 	chainHeaders := []string{"Miner", "Power", "RelativePower", "SectorSize"}
 	var chainRows [][]interface{}
 	i = 0
@@ -301,6 +301,11 @@ func (g *Gateway) reputationHandler(c *gin.Context) {
 		"Headers":   headers,
 		"Rows":      rows,
 	})
+}
+
+func epochToTime(value int64) time.Time {
+	genesisEpochTime := int64(1598295600)
+	return time.Unix(genesisEpochTime+value*30, 0)
 }
 
 func uint64ToTime(value int64) time.Time {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -308,10 +308,6 @@ func epochToTime(value int64) time.Time {
 	return time.Unix(genesisEpochTime+value*30, 0)
 }
 
-func uint64ToTime(value int64) time.Time {
-	return time.Unix(value, 0)
-}
-
 func timeToString(t time.Time) string {
 	return t.Format("01/02/06 3:04 PM")
 }


### PR DESCRIPTION
Some time ago we changed `LastUpdated` of on-chain index to being epochs, but was still being interpreted as unix-time, so printing `01/03/70 7:51 PM` was wrong.
Do the right transformation considering a Filecoin epoch is ~30s.

Other changes:
- Update Go version for Dockerfile.
- Update golangci-lint GH Action to v2, since v1 has a deprecated way of setting envs that GH today makes the action fail.

Tested in internal Pow.