### PR TITLE
Bump lotus docker image

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -16,7 +16,7 @@ localnet:
 
 
 up: down
-	LOTUS_IMAGE_TAG=v1.2.0 \
+	LOTUS_IMAGE_TAG=v1.2.1 \
 	docker-compose \
 		-p mainnet \
 		-f docker-compose.yaml \
@@ -26,7 +26,7 @@ up: down
 .PHONY: up
 
 down:
-	LOTUS_IMAGE_TAG=v1.2.0 \
+	LOTUS_IMAGE_TAG=v1.2.1 \
 	docker-compose \
 		-p mainnet \
 		-f docker-compose.yaml \


### PR DESCRIPTION
Lotus v1.2.0 might have problems if is bootstrapped from a snapshot without a previous state. This problem might be annoying for users that are starting a fresh Lotus node.

This PR upgrades to a new `textile/lotus` image based on [this](https://github.com/filecoin-project/lotus/releases/tag/v1.2.1) tag.