### PR TITLE
Correct value for start epoch in API

### DIFF
--- a/api/server/user/util.go
+++ b/api/server/user/util.go
@@ -243,7 +243,7 @@ func toRPCJob(job ffs.StorageJob) (*userPb.StorageJob, error) {
 			PricePerEpoch:   item.PricePerEpoch,
 			ProposalCid:     item.ProposalCid.String(),
 			Size:            item.Size,
-			StartEpoch:      item.Size,
+			StartEpoch:      item.StartEpoch,
 			StateId:         item.StateID,
 			StateName:       item.StateName,
 		}


### PR DESCRIPTION
Just a little bug