### PR TITLE
scheduler: add missing free-slot signal on resumed jobs

### DIFF
--- a/ffs/scheduler/scheduler.go
+++ b/ffs/scheduler/scheduler.go
@@ -370,6 +370,13 @@ func (s *Scheduler) resumeStartedDeals() error {
 
 			log.Infof("storage job resume rate limit: %d/%d", len(s.sd.rateLim), cap(s.sd.rateLim))
 			<-s.sd.rateLim
+
+			// Signal that a free slot is available for a queued job.
+			select {
+			case s.sd.evaluateQueue <- struct{}{}:
+			default:
+			}
+
 		}(j)
 	}
 	return nil

--- a/ffs/scheduler/scheduler.go
+++ b/ffs/scheduler/scheduler.go
@@ -376,7 +376,6 @@ func (s *Scheduler) resumeStartedDeals() error {
 			case s.sd.evaluateQueue <- struct{}{}:
 			default:
 			}
-
 		}(j)
 	}
 	return nil


### PR DESCRIPTION
This fixes signaling the scheduler on a free slot after a _resumed_ job finishes. 