### PR TITLE
sched: cancel queued & CLI helpers

### DIFF
--- a/cli-docs/pow/pow_storage-jobs.md
+++ b/cli-docs/pow/pow_storage-jobs.md
@@ -23,6 +23,8 @@ Provides commands to query for storage jobs in various statess
 
 * [pow](pow.md)	 - A client for storage and retreival of powergate data
 * [pow storage-jobs cancel](pow_storage-jobs_cancel.md)	 - Cancel an executing storage job
+* [pow storage-jobs cancel-executing](pow_storage-jobs_cancel-executing.md)	 - Cancel all executing jobs
+* [pow storage-jobs cancel-queued](pow_storage-jobs_cancel-queued.md)	 - Cancel all queued jobs
 * [pow storage-jobs executing](pow_storage-jobs_executing.md)	 - List executing storage jobs
 * [pow storage-jobs get](pow_storage-jobs_get.md)	 - Get a storage job's current status
 * [pow storage-jobs latest-final](pow_storage-jobs_latest-final.md)	 - List the latest final storage jobs

--- a/cli-docs/pow/pow_storage-jobs_cancel-executing.md
+++ b/cli-docs/pow/pow_storage-jobs_cancel-executing.md
@@ -1,0 +1,29 @@
+## pow storage-jobs cancel-executing
+
+Cancel all executing jobs
+
+### Synopsis
+
+Cancel all executing jobs
+
+```
+pow storage-jobs cancel-executing [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for cancel-executing
+```
+
+### Options inherited from parent commands
+
+```
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
+  -t, --token string           user auth token
+```
+
+### SEE ALSO
+
+* [pow storage-jobs](pow_storage-jobs.md)	 - Provides commands to query for storage jobs in various states
+

--- a/cli-docs/pow/pow_storage-jobs_cancel-queued.md
+++ b/cli-docs/pow/pow_storage-jobs_cancel-queued.md
@@ -1,0 +1,29 @@
+## pow storage-jobs cancel-queued
+
+Cancel all queued jobs
+
+### Synopsis
+
+Cancel all queued jobs
+
+```
+pow storage-jobs cancel-queued [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for cancel-queued
+```
+
+### Options inherited from parent commands
+
+```
+      --serverAddress string   address of the powergate service api (default "127.0.0.1:5002")
+  -t, --token string           user auth token
+```
+
+### SEE ALSO
+
+* [pow storage-jobs](pow_storage-jobs.md)	 - Provides commands to query for storage jobs in various states
+

--- a/cmd/pow/cmd/storage_jobs_cancel.go
+++ b/cmd/pow/cmd/storage_jobs_cancel.go
@@ -29,3 +29,51 @@ var storageJobsCancelCmd = &cobra.Command{
 		checkErr(err)
 	},
 }
+
+var storageJobsCancelQueuedCmd = &cobra.Command{
+	Use:   "cancel-queued",
+	Short: "Cancel all queued jobs",
+	Long:  "Cancel all queued jobs",
+	Args:  cobra.ExactArgs(0),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		err := viper.BindPFlags(cmd.Flags())
+		checkErr(err)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+
+		ctx = mustAuthCtx(ctx)
+		js, err := powClient.StorageJobs.Queued(ctx)
+		checkErr(err)
+
+		for _, j := range js.StorageJobs {
+			_, err := powClient.StorageJobs.Cancel(ctx, j.Id)
+			checkErr(err)
+		}
+	},
+}
+
+var storageJobsCancelExecutingCmd = &cobra.Command{
+	Use:   "cancel-executing",
+	Short: "Cancel all executing jobs",
+	Long:  "Cancel all executing jobs",
+	Args:  cobra.ExactArgs(0),
+	PreRun: func(cmd *cobra.Command, args []string) {
+		err := viper.BindPFlags(cmd.Flags())
+		checkErr(err)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+		defer cancel()
+
+		ctx = mustAuthCtx(ctx)
+		js, err := powClient.StorageJobs.Executing(ctx)
+		checkErr(err)
+
+		for _, j := range js.StorageJobs {
+			_, err := powClient.StorageJobs.Cancel(ctx, j.Id)
+			checkErr(err)
+		}
+	},
+}

--- a/cmd/pow/cmd/storage_jobs_cancel.go
+++ b/cmd/pow/cmd/storage_jobs_cancel.go
@@ -10,6 +10,8 @@ import (
 
 func init() {
 	storageJobsCmd.AddCommand(storageJobsCancelCmd)
+	storageJobsCmd.AddCommand(storageJobsCancelQueuedCmd)
+	storageJobsCmd.AddCommand(storageJobsCancelExecutingCmd)
 }
 
 var storageJobsCancelCmd = &cobra.Command{

--- a/cmd/pow/cmd/storage_jobs_cancel.go
+++ b/cmd/pow/cmd/storage_jobs_cancel.go
@@ -42,14 +42,15 @@ var storageJobsCancelQueuedCmd = &cobra.Command{
 		checkErr(err)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		defer cancel()
+		ctx := mustAuthCtx(context.Background())
 
-		ctx = mustAuthCtx(ctx)
 		js, err := powClient.StorageJobs.Queued(ctx)
 		checkErr(err)
 
 		for _, j := range js.StorageJobs {
+			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+			defer cancel()
+
 			_, err := powClient.StorageJobs.Cancel(ctx, j.Id)
 			checkErr(err)
 		}
@@ -66,14 +67,15 @@ var storageJobsCancelExecutingCmd = &cobra.Command{
 		checkErr(err)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-		defer cancel()
+		ctx := mustAuthCtx(context.Background())
 
-		ctx = mustAuthCtx(ctx)
 		js, err := powClient.StorageJobs.Executing(ctx)
 		checkErr(err)
 
 		for _, j := range js.StorageJobs {
+			ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+			defer cancel()
+
 			_, err := powClient.StorageJobs.Cancel(ctx, j.Id)
 			checkErr(err)
 		}


### PR DESCRIPTION
This PR:
- Makes Job canceling consider Queued jobs.
- Creates some CLI helpers to cancel all executing, and all queued jobs. This introduced no APIs since this feature using the CLI can be built with existing ones. I preferred not creating new APIs since that was unnecessary and also to not have bloated APIs.