### PR TITLE
Cid info fix + sorting storage jobs

### DIFF
--- a/api/server/user/data.go
+++ b/api/server/user/data.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 
 	userPb "github.com/textileio/powergate/api/gen/powergate/user/v1"
 	"github.com/textileio/powergate/ffs"
@@ -224,6 +225,9 @@ func (s *Service) CidInfo(ctx context.Context, req *userPb.CidInfoRequest) (*use
 		}
 		res = append(res, cidInfo)
 	}
+	sort.Slice(res, func(a, b int) bool {
+		return res[a].Cid < res[b].Cid
+	})
 	return &userPb.CidInfoResponse{CidInfos: res}, nil
 }
 

--- a/ffs/api/api.go
+++ b/ffs/api/api.go
@@ -125,7 +125,7 @@ func (i *API) GetStorageConfigs(cids ...cid.Cid) (map[cid.Cid]ffs.StorageConfig,
 		return nil, err
 	}
 	if err != nil {
-		return nil, fmt.Errorf("getting cid config from store: %s", err)
+		return nil, fmt.Errorf("getting cid configs from store: %s", err)
 	}
 	return configs, nil
 }

--- a/ffs/api/istore.go
+++ b/ffs/api/istore.go
@@ -88,10 +88,12 @@ func (s *instanceStore) getStorageConfigs(cids ...cid.Cid) (map[cid.Cid]ffs.Stor
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	rawRes := make(map[cid.Cid][]byte)
+	filter := make(map[cid.Cid]struct{})
 	for _, cid := range cids {
-		rawRes[cid] = nil
+		filter[cid] = struct{}{}
 	}
+
+	rawRes := make(map[cid.Cid][]byte)
 
 	if len(cids) == 1 {
 		// just getting a single value, do an explicit query for it
@@ -126,9 +128,9 @@ func (s *instanceStore) getStorageConfigs(cids ...cid.Cid) (map[cid.Cid]ffs.Stor
 			if err != nil {
 				return nil, fmt.Errorf("decoding cid: %s", err)
 			}
-			if len(rawRes) > 0 {
+			if len(filter) > 0 {
 				// we have a filter, check it
-				if _, ok := rawRes[c]; ok {
+				if _, ok := filter[c]; ok {
 					rawRes[c] = r.Value
 				}
 			} else {

--- a/ffs/scheduler/internal/sjstore/sjstore.go
+++ b/ffs/scheduler/internal/sjstore/sjstore.go
@@ -457,6 +457,11 @@ func mappedJobs(m map[ffs.APIID]map[cid.Cid]*ffs.StorageJob, iid ffs.APIID, cids
 			}
 		}
 	}
+
+	sort.Slice(res, func(a, b int) bool {
+		return res[a].CreatedAt < res[b].CreatedAt
+	})
+
 	return res
 }
 


### PR DESCRIPTION
There was a bug where the `Data.Info()` method was usually only returning one result. Fixed here.

Also adds sorting by cid to the results of `Data.Info()` and makes sure all storage job list responses are sorted by date.

closes #722 
