### PR TITLE
Data.Info(<cid>) get executing jobs for provided cid

### DIFF
--- a/api/server/user/data.go
+++ b/api/server/user/data.go
@@ -200,7 +200,7 @@ func (s *Service) CidInfo(ctx context.Context, req *userPb.CidInfoRequest) (*use
 		}
 		cidInfo.QueuedStorageJobs = rpcQueudJobs
 		executingJobs := i.ExecutingStorageJobs(cid)
-		if len(executingJobs) > 0 {
+		if len(executingJobs) == 1 {
 			// There is exactly one job in the slice because we specified a cid
 			// and there can be only one executing job per cid at a time.
 			rpcJob, err := toRPCJob(executingJobs[0])
@@ -208,6 +208,8 @@ func (s *Service) CidInfo(ctx context.Context, req *userPb.CidInfoRequest) (*use
 				return nil, status.Errorf(codes.Internal, "converting job to rpc job: %v", err)
 			}
 			cidInfo.ExecutingStorageJob = rpcJob
+		} else {
+			log.Warnf("received %d executing jobs when there should be 1", len(executingJobs))
 		}
 		finalJobs := i.LatestFinalStorageJobs(cid)
 		if len(finalJobs) > 0 {

--- a/api/server/user/data.go
+++ b/api/server/user/data.go
@@ -199,8 +199,10 @@ func (s *Service) CidInfo(ctx context.Context, req *userPb.CidInfoRequest) (*use
 			rpcQueudJobs[i] = rpcJob
 		}
 		cidInfo.QueuedStorageJobs = rpcQueudJobs
-		executingJobs := i.ExecutingStorageJobs()
+		executingJobs := i.ExecutingStorageJobs(cid)
 		if len(executingJobs) > 0 {
+			// There is exactly one job in the slice because we specified a cid
+			// and there can be only one executing job per cid at a time.
 			rpcJob, err := toRPCJob(executingJobs[0])
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "converting job to rpc job: %v", err)

--- a/api/server/user/service.go
+++ b/api/server/user/service.go
@@ -18,7 +18,7 @@ var (
 	// ErrEmptyAuthToken is returned when the provided auth-token is unknown.
 	ErrEmptyAuthToken = errors.New("auth token can't be empty")
 
-	log = logger.Logger("powergate-service")
+	log = logger.Logger("user-service")
 )
 
 // Service implements the Powergate API.

--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -273,7 +273,7 @@ func setupLogging(repoPath string) error {
 		"ffs-pinstore",
 
 		// gRPC Services
-		"powergate-service",
+		"user-service",
 	}
 
 	// powd registered loggers get info level by default.


### PR DESCRIPTION
This fixes a bug where random jobs from other cids with executing jobs were being listed in the results of `Data.Info(<cid>)`.