### PR TITLE
Make embedded logging setup optional to support ipfs/go-log environment variables

### DIFF
--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -273,7 +273,7 @@ func setupLogging(repoPath string) error {
 	// If at least one of them defined - do not override
 	// ipfs/go-log internal logging setup
 	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "GOLOG_LOG_") {
+		if strings.HasPrefix(e, "GOLOG_") {
 			ipfslog = true
 			break
 		}

--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -267,10 +268,16 @@ func setupLogging(repoPath string) error {
 		"user-service",
 	}
 
-	ipfslog := config.GetBool("ipfslog")
-	// If ipfslog is defined, the output format, destination and level
-	// can be managed via native to ipfs/go-log library
-	// environment variables (e.g. GOLOG_LOG_*)
+	var ipfslog bool
+	// Looking for ipfs/go-log setup environment variables
+	// If at least one of them defined - do not override
+	// ipfs/go-log internal logging setup
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "GOLOG_LOG_") {
+			ipfslog = true
+			break
+		}
+	}
 	if !ipfslog {
 		if err := os.MkdirAll(repoPath, os.ModePerm); err != nil {
 			return fmt.Errorf("creating repo folder: %s", err)
@@ -345,7 +352,6 @@ func getLotusToken(devnet bool) (string, error) {
 
 func setupFlags() error {
 	pflag.Bool("debug", false, "Enable debug log level in all loggers.")
-	pflag.Bool("ipfslog", false, "Enable native ipfs/go-log logging setup via supported env vars.")
 
 	pflag.Bool("autocreatemasteraddr", false, "Automatically creates & funds a master address if none is provided.")
 	pflag.Int64("walletinitialfund", 250_000_000_000_000_000, "FFS initial funding transaction amount in attoFIL received by --lotusmasteraddr. (if set)")


### PR DESCRIPTION
In this PR I tried to fix #733 by making internal logging setup optional via new command line flag (the name is not ideal, but that is the best I was able to come up with).

`ipfs/go-log` that is used for the logging purposes executes setup through environment variables on package initialization: https://github.com/ipfs/go-log/blob/4f3460899491d70a650f7fd6b10217cae6ba3c41/setup.go#L16

That is why I moved original code under `if` statement, so the explicit setup of the logging subsystem here: https://github.com/textileio/powergate/blob/2a8087695f184b06632df58b34db7c760b9fde01/cmd/powd/main.go#L228 
will not override `go-log` settings gathered via such variables.

W/o `ipfslog` flag defined the behavior remains the same.