### PR TITLE
Make lotus-devnet speed configurable for tests

### DIFF
--- a/api/client/utils_test.go
+++ b/api/client/utils_test.go
@@ -31,7 +31,7 @@ func defaultServerConfig(t *testing.T) server.Config {
 	ipfsAddrStr := "/ip4/127.0.0.1/tcp/" + dipfs.GetPort("5001/tcp")
 	ipfsAddr := util.MustParseAddr(ipfsAddrStr)
 
-	devnet := tests.LaunchDevnetDocker(t, 1, ipfsAddrStr, false)
+	devnet := tests.LaunchDevnetDocker(t, 1, 300, ipfsAddrStr, false)
 	devnetAddr := util.MustParseAddr("/ip4/127.0.0.1/tcp/" + devnet.GetPort("7777/tcp"))
 
 	grpcMaddr := util.MustParseAddr(grpcHostAddress)

--- a/chainsync/chainsync_test.go
+++ b/chainsync/chainsync_test.go
@@ -18,7 +18,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestPrecede(t *testing.T) {
-	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1)
+	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1, 300)
 	time.Sleep(time.Second * 5) // Give time for at least 1 block to be mined.
 	ctx := context.Background()
 	c, cls, err := clientBuilder(context.Background())

--- a/deals/module/deals_test.go
+++ b/deals/module/deals_test.go
@@ -48,7 +48,7 @@ func TestStore(t *testing.T) {
 		t.Run(fmt.Sprintf("CantMiners%d", nm), func(t *testing.T) {
 			t.Parallel()
 			tests.RunFlaky(t, func(t *tests.FlakyT) {
-				clientBuilder, addr, _ := tests.CreateLocalDevnet(t, nm)
+				clientBuilder, addr, _ := tests.CreateLocalDevnet(t, nm, 300)
 				m, err := New(tests.NewTxMapDatastore(), clientBuilder, util.AvgBlockTime, time.Minute*10, deals.WithImportPath(filepath.Join(tmpDir, "imports")))
 				require.NoError(t, err)
 				c, cls, err := clientBuilder(context.Background())
@@ -104,7 +104,7 @@ func TestRetrieve(t *testing.T) {
 			t.Parallel()
 			tests.RunFlaky(t, func(t *tests.FlakyT) {
 				data := randomBytes(600)
-				clientBuilder, addr, _ := tests.CreateLocalDevnet(t, nm)
+				clientBuilder, addr, _ := tests.CreateLocalDevnet(t, nm, 300)
 				m, err := New(tests.NewTxMapDatastore(), clientBuilder, util.AvgBlockTime, time.Minute*10, deals.WithImportPath(filepath.Join(tmpDir, "imports")))
 				require.NoError(t, err)
 				c, cls, err := clientBuilder(context.Background())

--- a/ffs/integrationtest/config/config_test.go
+++ b/ffs/integrationtest/config/config_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 
 func TestSetDefaultStorageConfig(t *testing.T) {
 	t.Parallel()
-	_, _, fapi, cls := itmanager.NewAPI(t, 1)
+	_, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	config := ffs.StorageConfig{
@@ -58,7 +58,7 @@ func TestEnabledConfigChange(t *testing.T) {
 		t.Parallel()
 		tests.RunFlaky(t, func(t *tests.FlakyT) {
 			ctx := context.Background()
-			ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+			ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 			defer cls()
 
 			r := rand.New(rand.NewSource(22))
@@ -83,7 +83,7 @@ func TestEnabledConfigChange(t *testing.T) {
 		t.Parallel()
 		tests.RunFlaky(t, func(t *tests.FlakyT) {
 			ctx := context.Background()
-			ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+			ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 			defer cls()
 
 			r := rand.New(rand.NewSource(22))
@@ -109,7 +109,7 @@ func TestEnabledConfigChange(t *testing.T) {
 
 		tests.RunFlaky(t, func(t *tests.FlakyT) {
 			ctx := context.Background()
-			ipfsAPI, client, fapi, cls := itmanager.NewAPI(t, 1)
+			ipfsAPI, client, fapi, cls := itmanager.NewAPI(t, 1, 300)
 			defer cls()
 
 			r := rand.New(rand.NewSource(22))
@@ -135,7 +135,7 @@ func TestEnabledConfigChange(t *testing.T) {
 
 		tests.RunFlaky(t, func(t *tests.FlakyT) {
 			ctx := context.Background()
-			ipfsAPI, client, fapi, cls := itmanager.NewAPI(t, 1)
+			ipfsAPI, client, fapi, cls := itmanager.NewAPI(t, 1, 300)
 			defer cls()
 
 			r := rand.New(rand.NewSource(22))
@@ -184,7 +184,7 @@ func TestFilecoinEnableConfig(t *testing.T) {
 			t.Parallel()
 
 			tests.RunFlaky(t, func(t *tests.FlakyT) {
-				ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+				ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 				defer cls()
 
 				r := rand.New(rand.NewSource(22))
@@ -234,7 +234,7 @@ func TestFilecoinEnableConfig(t *testing.T) {
 func TestHotTimeoutConfig(t *testing.T) {
 	t.SkipNow()
 	t.Parallel()
-	_, _, fapi, cls := itmanager.NewAPI(t, 1)
+	_, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	t.Run("ShortTime", func(t *testing.T) {
@@ -252,7 +252,7 @@ func TestDurationConfig(t *testing.T) {
 	t.Parallel()
 
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
-		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 		defer cls()
 
 		r := rand.New(rand.NewSource(22))
@@ -272,7 +272,7 @@ func TestDurationConfig(t *testing.T) {
 
 func TestGetDefaultStorageConfig(t *testing.T) {
 	t.Parallel()
-	_, _, fapi, cls := itmanager.NewAPI(t, 1)
+	_, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	defaultConf := fapi.DefaultStorageConfig()

--- a/ffs/integrationtest/filters/filters_test.go
+++ b/ffs/integrationtest/filters/filters_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 func TestFilecoinExcludedMiners(t *testing.T) {
 	t.Parallel()
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
-		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2)
+		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2, 300)
 		defer cls()
 
 		r := rand.New(rand.NewSource(22))
@@ -52,7 +52,7 @@ func TestFilecoinTrustedMiner(t *testing.T) {
 	t.Parallel()
 
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
-		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2)
+		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2, 300)
 		defer cls()
 
 		r := rand.New(rand.NewSource(22))
@@ -78,7 +78,7 @@ func TestFilecoinCountryFilter(t *testing.T) {
 		ipfs, ipfsAddr := it.CreateIPFS(t)
 		countries := []string{"China", "Uruguay"}
 		numMiners := len(countries)
-		client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, numMiners, ipfsAddr, false)
+		client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, numMiners, 300, ipfsAddr, false)
 		addrs := make([]string, numMiners)
 		for i := 0; i < numMiners; i++ {
 			addrs[i] = fmt.Sprintf("f0%d", 1000+i)
@@ -118,7 +118,7 @@ func TestFilecoinMaxPriceFilter(t *testing.T) {
 
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
 		ipfs, ipfsMAddr := it.CreateIPFS(t)
-		client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, 1, ipfsMAddr, false)
+		client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, 1, 300, ipfsMAddr, false)
 		miner := fixed.Miner{Addr: "f01000", EpochPrice: 500000000}
 		ms := fixed.New([]fixed.Miner{miner})
 		ds := tests.NewTxMapDatastore()

--- a/ffs/integrationtest/general/general_test.go
+++ b/ffs/integrationtest/general/general_test.go
@@ -33,7 +33,7 @@ func TestAdd(t *testing.T) {
 		t.Parallel()
 		tests.RunFlaky(t, func(t *tests.FlakyT) {
 			ctx := context.Background()
-			ipfsAPI, client, fapi, cls := itmanager.NewAPI(t, 1)
+			ipfsAPI, client, fapi, cls := itmanager.NewAPI(t, 1, 300)
 			defer cls()
 
 			r := rand.New(rand.NewSource(22))
@@ -53,7 +53,7 @@ func TestAdd(t *testing.T) {
 		t.Parallel()
 
 		tests.RunFlaky(t, func(t *tests.FlakyT) {
-			ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+			ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 			defer cls()
 
 			r := rand.New(rand.NewSource(22))
@@ -74,7 +74,7 @@ func TestGet(t *testing.T) {
 
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
 		ctx := context.Background()
-		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 		defer cls()
 
 		r := rand.New(rand.NewSource(22))
@@ -94,7 +94,7 @@ func TestGet(t *testing.T) {
 
 func TestDealConsistency(t *testing.T) {
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
-		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 		defer cls()
 
 		firstID := fapi.ID()
@@ -169,7 +169,7 @@ func TestShow(t *testing.T) {
 	t.Parallel()
 
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
-		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 
 		defer cls()
 
@@ -222,7 +222,7 @@ func TestColdInstanceLoad(t *testing.T) {
 
 		ds := tests.NewTxMapDatastore()
 		ipfs, ipfsMAddr := it.CreateIPFS(t)
-		addr, client, ms := itmanager.NewDevnet(t, 1, ipfsMAddr)
+		addr, client, ms := itmanager.NewDevnet(t, 1, 300, ipfsMAddr)
 		manager, closeManager := itmanager.NewFFSManager(t, ds, client, addr, ms, ipfs)
 
 		auth, err := manager.Create(context.Background())
@@ -274,7 +274,7 @@ func TestHighMinimumPieceSize(t *testing.T) {
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
 		ds := tests.NewTxMapDatastore()
 		ipfs, ipfsMAddr := it.CreateIPFS(t)
-		addr, client, ms := itmanager.NewDevnet(t, 1, ipfsMAddr)
+		addr, client, ms := itmanager.NewDevnet(t, 1, 300, ipfsMAddr)
 		// Set MinimumPieceSize to 1GB so to force failing
 		manager, _, closeManager := itmanager.NewCustomFFSManager(t, ds, client, addr, ms, ipfs, 1024*1024*1024)
 		defer closeManager()
@@ -301,7 +301,7 @@ func TestStageCidUnpinedOnDisabledHotStorage(t *testing.T) {
 		ctx := context.Background()
 		ds := tests.NewTxMapDatastore()
 		ipfs, ipfsMAddr := it.CreateIPFS(t)
-		addr, client, ms := itmanager.NewDevnet(t, 1, ipfsMAddr)
+		addr, client, ms := itmanager.NewDevnet(t, 1, 300, ipfsMAddr)
 		manager, hs, closeManager := itmanager.NewCustomFFSManager(t, ds, client, addr, ms, ipfs, 0)
 		defer closeManager()
 		auth, err := manager.Create(context.Background())
@@ -332,7 +332,7 @@ func TestRemove(t *testing.T) {
 	t.Parallel()
 
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
-		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 		defer cls()
 
 		r := rand.New(rand.NewSource(22))

--- a/ffs/integrationtest/importing/importing_test.go
+++ b/ffs/integrationtest/importing/importing_test.go
@@ -20,7 +20,7 @@ func TestImportWithoutRetrievalTwoUsers(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ipfsAPI, ipfsMAddr := it.CreateIPFS(t)
-	addr, client, ms := itmanager.NewDevnet(t, 1, ipfsMAddr)
+	addr, client, ms := itmanager.NewDevnet(t, 1, 300, ipfsMAddr)
 	manager, closeManager := itmanager.NewFFSManager(t, ds, client, addr, ms, ipfsAPI)
 	defer closeManager()
 
@@ -76,7 +76,7 @@ func TestImportWithoutRetrievalTwoUsers(t *testing.T) {
 func TestImportWithRetrievalSingleUser(t *testing.T) {
 	t.Parallel()
 
-	ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+	ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	// Add some data to Filecoin.

--- a/ffs/integrationtest/logger/logger_test.go
+++ b/ffs/integrationtest/logger/logger_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 
 func TestLogHistory(t *testing.T) {
 	t.Parallel()
-	ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+	ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	r := rand.New(rand.NewSource(22))
@@ -59,7 +59,7 @@ func TestLogHistory(t *testing.T) {
 func TestCidLogger(t *testing.T) {
 	t.Parallel()
 	t.Run("WithNoFilters", func(t *testing.T) {
-		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 		defer cls()
 
 		r := rand.New(rand.NewSource(22))
@@ -98,7 +98,7 @@ func TestCidLogger(t *testing.T) {
 	})
 	t.Run("WithJidFilter", func(t *testing.T) {
 		t.Run("CorrectJid", func(t *testing.T) {
-			ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+			ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 			defer cls()
 
 			r := rand.New(rand.NewSource(22))
@@ -136,7 +136,7 @@ func TestCidLogger(t *testing.T) {
 			it.RequireStorageConfig(t, fapi, cid, nil)
 		})
 		t.Run("IncorrectJid", func(t *testing.T) {
-			ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+			ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 			defer cls()
 
 			r := rand.New(rand.NewSource(22))

--- a/ffs/integrationtest/manager/manager.go
+++ b/ffs/integrationtest/manager/manager.go
@@ -35,10 +35,10 @@ const (
 )
 
 // NewAPI returns a new set of components for FFS.
-func NewAPI(t tests.TestingTWithCleanup, numMiners int) (*httpapi.HttpApi, *apistruct.FullNodeStruct, *api.API, func()) {
+func NewAPI(t tests.TestingTWithCleanup, numMiners, speed int) (*httpapi.HttpApi, *apistruct.FullNodeStruct, *api.API, func()) {
 	ds := tests.NewTxMapDatastore()
 	ipfs, ipfsMAddr := it.CreateIPFS(t)
-	addr, clientBuilder, ms := NewDevnet(t, numMiners, ipfsMAddr)
+	addr, clientBuilder, ms := NewDevnet(t, numMiners, speed, ipfsMAddr)
 	manager, closeManager := NewFFSManager(t, ds, clientBuilder, addr, ms, ipfs)
 	auth, err := manager.Create(context.Background())
 	require.NoError(t, err)
@@ -56,8 +56,8 @@ func NewAPI(t tests.TestingTWithCleanup, numMiners int) (*httpapi.HttpApi, *apis
 }
 
 // NewDevnet creates a localnet.
-func NewDevnet(t tests.TestingTWithCleanup, numMiners int, ipfsAddr string) (address.Address, lotus.ClientBuilder, ffs.MinerSelector) {
-	client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, numMiners, ipfsAddr, false)
+func NewDevnet(t tests.TestingTWithCleanup, numMiners, speed int, ipfsAddr string) (address.Address, lotus.ClientBuilder, ffs.MinerSelector) {
+	client, addr, _ := tests.CreateLocalDevnetWithIPFS(t, numMiners, speed, ipfsAddr, false)
 	addrs := make([]string, numMiners)
 	for i := 0; i < numMiners; i++ {
 		addrs[i] = fmt.Sprintf("f0%d", 1000+i)

--- a/ffs/integrationtest/renew/renew_test.go
+++ b/ffs/integrationtest/renew/renew_test.go
@@ -29,7 +29,7 @@ func TestRenew(t *testing.T) {
 	t.SkipNow()
 
 	t.Parallel()
-	ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+	ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	ra := rand.New(rand.NewSource(22))

--- a/ffs/integrationtest/repair/repair_test.go
+++ b/ffs/integrationtest/repair/repair_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 func TestRepair(t *testing.T) {
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
 		scheduler.RepairEvalFrequency = time.Second * 30
-		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 		defer cls()
 
 		r := rand.New(rand.NewSource(22))

--- a/ffs/integrationtest/repfactor/repfactor_test.go
+++ b/ffs/integrationtest/repfactor/repfactor_test.go
@@ -32,7 +32,7 @@ func TestRepFactor(t *testing.T) {
 			t.Parallel()
 			tests.RunFlaky(t, func(t *tests.FlakyT) {
 				r := rand.New(rand.NewSource(22))
-				ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, rf)
+				ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, rf, 300)
 				defer cls()
 				cid, _ := it.AddRandomFile(t, r, ipfsAPI)
 				config := fapi.DefaultStorageConfig().WithColdFilRepFactor(rf)
@@ -53,7 +53,7 @@ func TestRepFactorIncrease(t *testing.T) {
 	t.SkipNow()
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
 		r := rand.New(rand.NewSource(22))
-		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2)
+		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2, 300)
 		defer cls()
 		cid, _ := it.AddRandomFile(t, r, ipfsAPI)
 		jid, err := fapi.PushStorageConfig(cid)
@@ -81,7 +81,7 @@ func TestRepFactorIncrease(t *testing.T) {
 func TestRepFactorDecrease(t *testing.T) {
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
 		r := rand.New(rand.NewSource(22))
-		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2)
+		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2, 300)
 		defer cls()
 
 		cid, _ := it.AddRandomFile(t, r, ipfsAPI)
@@ -110,7 +110,7 @@ func TestRepFactorDecrease(t *testing.T) {
 func TestRenewWithDecreasedRepFactor(t *testing.T) {
 	// Too flaky for CI.
 	t.SkipNow()
-	ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2)
+	ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 2, 300)
 	defer cls()
 
 	ra := rand.New(rand.NewSource(22))

--- a/ffs/integrationtest/replace/replace_test.go
+++ b/ffs/integrationtest/replace/replace_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 func TestPushCidReplace(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	ipfs, client, fapi, cls := itmanager.NewAPI(t, 1)
+	ipfs, client, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	r := rand.New(rand.NewSource(22))
@@ -66,7 +66,7 @@ func TestDoubleReplace(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ipfs, ipfsMAddr := it.CreateIPFS(t)
-	addr, client, ms := itmanager.NewDevnet(t, 1, ipfsMAddr)
+	addr, client, ms := itmanager.NewDevnet(t, 1, 300, ipfsMAddr)
 	m, closeManager := itmanager.NewFFSManager(t, ds, client, addr, ms, ipfs)
 	defer closeManager()
 

--- a/ffs/integrationtest/retrieval/retrieval_test.go
+++ b/ffs/integrationtest/retrieval/retrieval_test.go
@@ -34,7 +34,7 @@ func TestPartialRetrievalFlow(t *testing.T) {
 	t.Parallel()
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
 		ctx := context.Background()
-		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 		defer cls()
 		_ = ctx
 		_ = fapi

--- a/ffs/integrationtest/scheduler/scheduler_test.go
+++ b/ffs/integrationtest/scheduler/scheduler_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 
 func TestJobCancelation(t *testing.T) {
 	r := rand.New(rand.NewSource(22))
-	ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+	ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	cid, _ := it.AddRandomFile(t, r, ipfsAPI)
@@ -47,7 +47,7 @@ func TestJobCancelation(t *testing.T) {
 
 func TestParallelExecution(t *testing.T) {
 	t.Parallel()
-	ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+	ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	r := rand.New(rand.NewSource(22))
@@ -82,7 +82,7 @@ func TestResumeScheduler(t *testing.T) {
 
 	ds := tests.NewTxMapDatastore()
 	ipfs, ipfsMAddr := it.CreateIPFS(t)
-	addr, client, ms := itmanager.NewDevnet(t, 1, ipfsMAddr)
+	addr, client, ms := itmanager.NewDevnet(t, 1, 300, ipfsMAddr)
 	manager, closeManager := itmanager.NewFFSManager(t, ds, client, addr, ms, ipfs)
 	auth, err := manager.Create(context.Background())
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestResumeScheduler(t *testing.T) {
 
 func TestFailedJobMessage(t *testing.T) {
 	t.Parallel()
-	ipfs, _, fapi, cls := itmanager.NewAPI(t, 1)
+	ipfs, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	r := rand.New(rand.NewSource(22))

--- a/ffs/integrationtest/unfreeze/unfreeze_test.go
+++ b/ffs/integrationtest/unfreeze/unfreeze_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 func TestUnfreeze(t *testing.T) {
 	t.Parallel()
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
-		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 		defer cls()
 
 		ra := rand.New(rand.NewSource(22))
@@ -64,7 +64,7 @@ func TestUnfreeze(t *testing.T) {
 func TestUnfreezeRecords(t *testing.T) {
 	t.Parallel()
 	tests.RunFlaky(t, func(t *tests.FlakyT) {
-		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1)
+		ipfsAPI, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 		defer cls()
 
 		// Step 1. Produce a Filecoin retrieval.

--- a/ffs/integrationtest/wallet/wallet_test.go
+++ b/ffs/integrationtest/wallet/wallet_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 
 func TestAddrs(t *testing.T) {
 	t.Parallel()
-	_, _, fapi, cls := itmanager.NewAPI(t, 1)
+	_, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	addrs := fapi.Addrs()
@@ -38,7 +38,7 @@ func TestAddrs(t *testing.T) {
 
 func TestNewAddress(t *testing.T) {
 	t.Parallel()
-	_, _, fapi, cls := itmanager.NewAPI(t, 1)
+	_, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	addr, err := fapi.NewAddr(context.Background(), "my address")
@@ -51,7 +51,7 @@ func TestNewAddress(t *testing.T) {
 
 func TestNewAddressDefault(t *testing.T) {
 	t.Parallel()
-	_, _, fapi, cls := itmanager.NewAPI(t, 1)
+	_, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	addr, err := fapi.NewAddr(context.Background(), "my address", api.WithMakeDefault(true))
@@ -64,7 +64,7 @@ func TestNewAddressDefault(t *testing.T) {
 func TestSendFil(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	_, api, fapi, cls := itmanager.NewAPI(t, 1)
+	_, api, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	const amt int64 = 1
@@ -112,7 +112,7 @@ func TestSendFil(t *testing.T) {
 func TestSignVerifyMessage(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	_, _, fapi, cls := itmanager.NewAPI(t, 1)
+	_, _, fapi, cls := itmanager.NewAPI(t, 1, 300)
 	defer cls()
 
 	addrs := fapi.Addrs()

--- a/ffs/manager/manager_test.go
+++ b/ffs/manager/manager_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 
 func TestNewManager(t *testing.T) {
 	t.Parallel()
-	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	client, addr, _ := tests.CreateLocalDevnet(t, 1, 300)
 	m, cls, err := newManager(client, tests.NewTxMapDatastore(), addr, false)
 	require.NoError(t, err)
 	require.NotNil(t, m)
@@ -35,7 +35,7 @@ func TestNewManager(t *testing.T) {
 
 func TestNewManagerMasterAddrFFSUseMasterAddr(t *testing.T) {
 	t.Parallel()
-	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	client, addr, _ := tests.CreateLocalDevnet(t, 1, 300)
 	m, cls, err := newManager(client, tests.NewTxMapDatastore(), addr, true)
 	require.NoError(t, err)
 	require.NotNil(t, m)
@@ -44,7 +44,7 @@ func TestNewManagerMasterAddrFFSUseMasterAddr(t *testing.T) {
 
 func TestNewManagerNoMasterAddrNoFFSUseMasterAddr(t *testing.T) {
 	t.Parallel()
-	client, _, _ := tests.CreateLocalDevnet(t, 1)
+	client, _, _ := tests.CreateLocalDevnet(t, 1, 300)
 	m, cls, err := newManager(client, tests.NewTxMapDatastore(), address.Undef, false)
 	require.NoError(t, err)
 	require.NotNil(t, m)
@@ -53,7 +53,7 @@ func TestNewManagerNoMasterAddrNoFFSUseMasterAddr(t *testing.T) {
 
 func TestNewManagerNoMasterAddrFFSUseMasterAddr(t *testing.T) {
 	t.Parallel()
-	client, _, _ := tests.CreateLocalDevnet(t, 1)
+	client, _, _ := tests.CreateLocalDevnet(t, 1, 300)
 	_, cls, err := newManager(client, tests.NewTxMapDatastore(), address.Undef, true)
 	require.Error(t, err)
 	defer require.NoError(t, cls())
@@ -63,7 +63,7 @@ func TestCreate(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ctx := context.Background()
-	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	client, addr, _ := tests.CreateLocalDevnet(t, 1, 300)
 	m, cls, err := newManager(client, ds, addr, false)
 	require.NoError(t, err)
 	defer require.NoError(t, cls())
@@ -78,7 +78,7 @@ func TestCreateWithFFSMasterAddr(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ctx := context.Background()
-	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	client, addr, _ := tests.CreateLocalDevnet(t, 1, 300)
 	m, cls, err := newManager(client, ds, addr, true)
 	require.NoError(t, err)
 	defer require.NoError(t, cls())
@@ -101,7 +101,7 @@ func TestList(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ctx := context.Background()
-	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	client, addr, _ := tests.CreateLocalDevnet(t, 1, 300)
 	m, cls, err := newManager(client, ds, addr, false)
 	require.NoError(t, err)
 	defer require.NoError(t, cls())
@@ -131,7 +131,7 @@ func TestGetByAuthToken(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
 	ctx := context.Background()
-	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	client, addr, _ := tests.CreateLocalDevnet(t, 1, 300)
 	m, cls, err := newManager(client, ds, addr, false)
 	require.NoError(t, err)
 	defer require.NoError(t, cls())
@@ -145,7 +145,7 @@ func TestGetByAuthToken(t *testing.T) {
 		require.NotEmpty(t, new.Addrs())
 	})
 	t.Run("Cold", func(t *testing.T) {
-		client, addr, _ := tests.CreateLocalDevnet(t, 1)
+		client, addr, _ := tests.CreateLocalDevnet(t, 1, 300)
 		m, cls, err := newManager(client, ds, addr, false)
 		require.NoError(t, err)
 		defer require.NoError(t, cls())
@@ -164,7 +164,7 @@ func TestGetByAuthToken(t *testing.T) {
 func TestDefaultStorageConfig(t *testing.T) {
 	t.Parallel()
 	ds := tests.NewTxMapDatastore()
-	client, addr, _ := tests.CreateLocalDevnet(t, 1)
+	client, addr, _ := tests.CreateLocalDevnet(t, 1, 300)
 	m, cls, err := newManager(client, ds, addr, true)
 	require.NoError(t, err)
 	defer require.NoError(t, cls())

--- a/index/ask/runner/runner_test.go
+++ b/index/ask/runner/runner_test.go
@@ -24,7 +24,7 @@ func TestFreshBuild(t *testing.T) {
 	// when querying Asks.
 	t.SkipNow()
 	ctx := context.Background()
-	clientBuilder, _, miners := tests.CreateLocalDevnet(t, 1)
+	clientBuilder, _, miners := tests.CreateLocalDevnet(t, 1, 300)
 	c, cls, err := clientBuilder(ctx)
 	require.NoError(t, err)
 	defer cls()

--- a/index/faults/module/faults_test.go
+++ b/index/faults/module/faults_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 func TestFreshIndex(t *testing.T) {
 	// Skipped until #235 lands.
 	t.SkipNow()
-	client, _, _ := tests.CreateLocalDevnet(t, 1)
+	client, _, _ := tests.CreateLocalDevnet(t, 1, 300)
 	time.Sleep(time.Millisecond * 500) // Allow the network to some tipsets
 
 	sh, err := New(tests.NewTxMapDatastore(), client, false)

--- a/index/miner/module/miner_test.go
+++ b/index/miner/module/miner_test.go
@@ -25,7 +25,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestFullRefresh(t *testing.T) {
-	client, _, miners := tests.CreateLocalDevnet(t, 1)
+	client, _, miners := tests.CreateLocalDevnet(t, 1, 300)
 	time.Sleep(time.Second * 15) // Allow the network to some tipsets
 
 	mi, err := New(tests.NewTxMapDatastore(), client, &p2pHostMock{}, &lrMock{}, false)

--- a/lotus/client_test.go
+++ b/lotus/client_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestClientImport(t *testing.T) {
-	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1)
+	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1, 300)
 	client, cls, err := clientBuilder(context.Background())
 	require.NoError(t, err)
 	defer cls()
@@ -63,7 +63,7 @@ func TestClientImport(t *testing.T) {
 }
 
 func TestClientChainNotify(t *testing.T) {
-	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1)
+	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1, 300)
 	client, cls, err := clientBuilder(context.Background())
 	require.NoError(t, err)
 	defer cls()
@@ -89,7 +89,7 @@ func TestClientChainNotify(t *testing.T) {
 }
 
 func TestChainHead(t *testing.T) {
-	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1)
+	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1, 300)
 	client, cls, err := clientBuilder(context.Background())
 	require.NoError(t, err)
 	defer cls()
@@ -101,7 +101,7 @@ func TestChainHead(t *testing.T) {
 }
 
 func TestChainGetTipset(t *testing.T) {
-	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1)
+	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1, 300)
 	client, cls, err := clientBuilder(context.Background())
 	require.NoError(t, err)
 	defer cls()
@@ -116,7 +116,7 @@ func TestChainGetTipset(t *testing.T) {
 }
 
 func TestGetPeerID(t *testing.T) {
-	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1)
+	clientBuilder, _, _ := tests.CreateLocalDevnet(t, 1, 300)
 	client, cls, err := clientBuilder(context.Background())
 	require.NoError(t, err)
 	defer cls()

--- a/tests/ldevnet.go
+++ b/tests/ldevnet.go
@@ -23,12 +23,12 @@ type TestingTWithCleanup interface {
 }
 
 // LaunchDevnetDocker launches the devnet docker image.
-func LaunchDevnetDocker(t TestingTWithCleanup, numMiners int, ipfsMaddr string, mountVolumes bool) *dockertest.Resource {
+func LaunchDevnetDocker(t TestingTWithCleanup, numMiners, speed int, ipfsMaddr string, mountVolumes bool) *dockertest.Resource {
 	pool, err := dockertest.NewPool("")
 	require.NoError(t, err)
 	envs := []string{
 		devnetEnv("NUMMINERS", strconv.Itoa(numMiners)),
-		devnetEnv("SPEED", "300"),
+		devnetEnv("SPEED", strconv.Itoa(speed)),
 		devnetEnv("IPFSADDR", ipfsMaddr),
 		devnetEnv("BIGSECTORS", false),
 	}
@@ -73,8 +73,8 @@ func LaunchDevnetDocker(t TestingTWithCleanup, numMiners int, ipfsMaddr string, 
 }
 
 // CreateLocalDevnetWithIPFS creates a local devnet connected to an IPFS node.
-func CreateLocalDevnetWithIPFS(t TestingTWithCleanup, numMiners int, ipfsMaddr string, mountVolumes bool) (lotus.ClientBuilder, address.Address, []address.Address) {
-	lotusDevnet := LaunchDevnetDocker(t, numMiners, ipfsMaddr, mountVolumes)
+func CreateLocalDevnetWithIPFS(t TestingTWithCleanup, numMiners, speed int, ipfsMaddr string, mountVolumes bool) (lotus.ClientBuilder, address.Address, []address.Address) {
+	lotusDevnet := LaunchDevnetDocker(t, numMiners, speed, ipfsMaddr, mountVolumes)
 	cb, err := lotus.NewBuilder(util.MustParseAddr("/ip4/127.0.0.1/tcp/"+lotusDevnet.GetPort("7777/tcp")), "", 1)
 	require.NoError(t, err)
 	ctx, cls := context.WithTimeout(context.Background(), time.Second*10)
@@ -93,8 +93,8 @@ func CreateLocalDevnetWithIPFS(t TestingTWithCleanup, numMiners int, ipfsMaddr s
 
 // CreateLocalDevnet returns an API client that targets a local devnet with numMiners number
 // of miners. Refer to http://github.com/textileio/local-devnet for more information.
-func CreateLocalDevnet(t TestingTWithCleanup, numMiners int) (lotus.ClientBuilder, address.Address, []address.Address) {
-	return CreateLocalDevnetWithIPFS(t, numMiners, "", true)
+func CreateLocalDevnet(t TestingTWithCleanup, numMiners, speed int) (lotus.ClientBuilder, address.Address, []address.Address) {
+	return CreateLocalDevnetWithIPFS(t, numMiners, speed, "", true)
 }
 
 func devnetEnv(name string, value interface{}) string {


### PR DESCRIPTION
Pretty simple one, just making a new argument to the helper functions then updating all the tests.