### PR TITLE
Move to not using multiaddr for config values

### DIFF
--- a/api/client/utils_test.go
+++ b/api/client/utils_test.go
@@ -32,7 +32,7 @@ func defaultServerConfig(t *testing.T) server.Config {
 	ipfsAddr := util.MustParseAddr(ipfsAddrStr)
 
 	devnet := tests.LaunchDevnetDocker(t, 1, 300, ipfsAddrStr, false)
-	devnetAddr := util.MustParseAddr("/ip4/127.0.0.1/tcp/" + devnet.GetPort("7777/tcp"))
+	devnetAddr := "127.0.0.1/tcp/" + devnet.GetPort("7777/tcp")
 
 	grpcMaddr := util.MustParseAddr(grpcHostAddress)
 	conf := server.Config{

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -109,7 +109,7 @@ type Config struct {
 	Devnet          bool
 	IpfsAPIAddr     ma.Multiaddr
 
-	LotusAddress           ma.Multiaddr
+	LotusAddress           string
 	LotusAuthToken         string
 	LotusMasterAddr        string
 	LotusConnectionRetries int

--- a/cmd/powd/main.go
+++ b/cmd/powd/main.go
@@ -106,10 +106,7 @@ func configFromFlags() (server.Config, error) {
 		return server.Config{}, fmt.Errorf("parsing grpchostaddr: %s", err)
 	}
 
-	lotusHost, err := ma.NewMultiaddr(config.GetString("lotushost"))
-	if err != nil {
-		return server.Config{}, fmt.Errorf("parsing lotus api multiaddr: %s", err)
-	}
+	lotusHost := config.GetString("lotushost")
 
 	walletInitialFunds := *big.NewInt(config.GetInt64("walletinitialfund"))
 	ipfsAPIAddr := util.MustParseAddr(config.GetString("ipfsapiaddr"))
@@ -365,7 +362,7 @@ func setupFlags() error {
 	pflag.String("grpcwebproxyaddr", "0.0.0.0:6002", "gRPC webproxy listening address.")
 	pflag.String("indexrawjsonhostaddr", "0.0.0.0:8889", "Indexes raw json output listening address")
 
-	pflag.String("lotushost", "/ip4/127.0.0.1/tcp/1234", "Lotus client API endpoint multiaddress.")
+	pflag.String("lotushost", "127.0.0.1:1234", "Lotus client API endpoint address.")
 	pflag.String("lotustoken", "", "Lotus API authorization token. This flag or --lotustoken file are mandatory.")
 	pflag.String("lotustokenfile", "", "Path of a file that contains the Lotus API authorization token.")
 	pflag.String("lotusmasteraddr", "", "Existing wallet address in Lotus to be used as source of funding for new FFS instances. (Optional)")

--- a/ffs/minerselector/sr2/sr2_test.go
+++ b/ffs/minerselector/sr2/sr2_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/filecoin-project/go-address"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 	"github.com/textileio/powergate/v2/ffs"
 	"github.com/textileio/powergate/v2/lotus"
@@ -16,11 +15,9 @@ import (
 // synced Lotus node.
 func TestMS(t *testing.T) {
 	t.SkipNow()
-	lotusHost, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/5555")
-	require.NoError(t, err)
 	lotusToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.4KpuySIvV4n6kBEXQOle-hi1Ec3lyUmRYCknz4NQyLM"
 
-	cb, err := lotus.NewBuilder(lotusHost, lotusToken, 1)
+	cb, err := lotus.NewBuilder("127.0.0.1:5555", lotusToken, 1)
 	require.NoError(t, err)
 
 	url := "https://raw.githubusercontent.com/filecoin-project/slingshot/master/miners.json"
@@ -35,11 +32,9 @@ func TestMS(t *testing.T) {
 
 func TestCustom(t *testing.T) {
 	t.SkipNow()
-	lotusHost, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/5555")
-	require.NoError(t, err)
 	lotusToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.4KpuySIvV4n6kBEXQOle-hi1Ec3lyUmRYCknz4NQyLM"
 
-	cb, err := lotus.NewBuilder(lotusHost, lotusToken, 1)
+	cb, err := lotus.NewBuilder("127.0.0.1:5555", lotusToken, 1)
 	require.NoError(t, err)
 
 	c, cls, err := cb(context.Background())

--- a/index/miner/module/miner_test.go
+++ b/index/miner/module/miner_test.go
@@ -62,11 +62,9 @@ func TestIntegration(t *testing.T) {
 	metaRefreshInterval = time.Hour
 	minersRefreshInterval = time.Second
 
-	lotusHost, err := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/5555")
-	require.NoError(t, err)
 	lotusToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.4KpuySIvV4n6kBEXQOle-hi1Ec3lyUmRYCknz4NQyLM"
 
-	cb, err := lotus.NewBuilder(lotusHost, lotusToken, 1)
+	cb, err := lotus.NewBuilder("127.0.0.1:5555", lotusToken, 1)
 	require.NoError(t, err)
 
 	mi, err := New(tests.NewTxMapDatastore(), cb, &p2pHostMock{}, &lrMock{}, false, false)

--- a/lotus/client.go
+++ b/lotus/client.go
@@ -9,9 +9,6 @@ import (
 	"github.com/filecoin-project/go-jsonrpc"
 	"github.com/filecoin-project/lotus/api/apistruct"
 	logging "github.com/ipfs/go-log/v2"
-	ma "github.com/multiformats/go-multiaddr"
-
-	"github.com/textileio/powergate/v2/util"
 )
 
 var (
@@ -22,11 +19,7 @@ var (
 type ClientBuilder func(ctx context.Context) (*apistruct.FullNodeStruct, func(), error)
 
 // NewBuilder creates a new ClientBuilder.
-func NewBuilder(maddr ma.Multiaddr, authToken string, connRetries int) (ClientBuilder, error) {
-	addr, err := util.TCPAddrFromMultiAddr(maddr)
-	if err != nil {
-		return nil, err
-	}
+func NewBuilder(addr string, authToken string, connRetries int) (ClientBuilder, error) {
 	headers := http.Header{
 		"Authorization": []string{"Bearer " + authToken},
 	}

--- a/tests/ldevnet.go
+++ b/tests/ldevnet.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ory/dockertest/v3/docker"
 	"github.com/stretchr/testify/require"
 	"github.com/textileio/powergate/v2/lotus"
-	"github.com/textileio/powergate/v2/util"
 )
 
 // TestingTWithCleanup is an augmented require.TestingT with a Cleanup function.
@@ -75,7 +74,7 @@ func LaunchDevnetDocker(t TestingTWithCleanup, numMiners, speed int, ipfsMaddr s
 // CreateLocalDevnetWithIPFS creates a local devnet connected to an IPFS node.
 func CreateLocalDevnetWithIPFS(t TestingTWithCleanup, numMiners, speed int, ipfsMaddr string, mountVolumes bool) (lotus.ClientBuilder, address.Address, []address.Address) {
 	lotusDevnet := LaunchDevnetDocker(t, numMiners, speed, ipfsMaddr, mountVolumes)
-	cb, err := lotus.NewBuilder(util.MustParseAddr("/ip4/127.0.0.1/tcp/"+lotusDevnet.GetPort("7777/tcp")), "", 1)
+	cb, err := lotus.NewBuilder("127.0.0.1:"+lotusDevnet.GetPort("7777/tcp"), "", 1)
 	require.NoError(t, err)
 	ctx, cls := context.WithTimeout(context.Background(), time.Second*10)
 	defer cls()


### PR DESCRIPTION
Per a conversation today with @sanderpick and @textileben . So far, I've only update the lotus address to be plain old `host:port`, but we can take this all the way. Let me know what you think.