### PR TITLE
update to Lotus v1.8.0

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -20,7 +20,7 @@ localnet:
 
 up: down
 	DOCKER_BUILDKIT=1 \
-	LOTUS_IMAGE_TAG=v1.6.0 \
+	LOTUS_IMAGE_TAG=v1.8.0 \
 	docker-compose \
 		-p mainnet \
 		-f docker-compose.yaml \
@@ -31,7 +31,7 @@ up: down
 
 down:
 	DOCKER_BUILDKIT=1 \
-	LOTUS_IMAGE_TAG=v1.6.0 \
+	LOTUS_IMAGE_TAG=v1.8.0 \
 	docker-compose \
 		-p mainnet \
 		-f docker-compose.yaml \

--- a/docker/docker-compose-localnet.yaml
+++ b/docker/docker-compose-localnet.yaml
@@ -23,7 +23,7 @@ services:
       - 5001:5001
 
   lotus:
-    image: textile/lotus-devnet:v1.6.0
+    image: textile/lotus-devnet:v1.8.0
     ports:
       - 7777:7777
     environment:

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/filecoin-project/go-fil-markets v1.1.9
 	github.com/filecoin-project/go-jsonrpc v0.1.4-0.20210217175800-45ea43ac2bec
 	github.com/filecoin-project/go-state-types v0.1.0
-	github.com/filecoin-project/lotus v1.6.0
+	github.com/filecoin-project/lotus v1.8.0
 	github.com/gin-contrib/location v0.0.2
 	github.com/gin-contrib/static v0.0.0-20191128031702-f81c604d8ac2
 	github.com/gin-gonic/gin v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,8 @@ github.com/filecoin-project/go-statestore v0.1.1-0.20210311122610-6c7a5aedbdea h
 github.com/filecoin-project/go-statestore v0.1.1-0.20210311122610-6c7a5aedbdea/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b h1:fkRZSPrYpk42PV3/lIXiL0LHetxde7vyYYvSsttQtfg=
 github.com/filecoin-project/go-storedcounter v0.0.0-20200421200003-1c99c62e8a5b/go.mod h1:Q0GQOBtKf1oE10eSXSlhN45kDBdGvEcVOqMiffqX+N8=
-github.com/filecoin-project/lotus v1.6.0 h1:LIor8joaJzNXvAAy8Mm+3krXmrzJXCS60h/hI1NgZmA=
-github.com/filecoin-project/lotus v1.6.0/go.mod h1:jDVPgwRg/4Zw03VN5bIWR+cgEzzgbrKzGaRwxc2KGTA=
+github.com/filecoin-project/lotus v1.8.0 h1:X6dUvvOvDkuWjsAOmMIK/23AMfkM18T0R1CUaIEELTA=
+github.com/filecoin-project/lotus v1.8.0/go.mod h1:a4vfqKJ2ynqg5TXpcPer/orWZIKBwJAv5TsBUj1PrSQ=
 github.com/filecoin-project/specs-actors v0.6.1/go.mod h1:dRdy3cURykh2R8O/DKqy8olScl70rmIS7GrB4hB1IDY=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/filecoin-project/specs-actors v0.9.12/go.mod h1:TS1AW/7LbG+615j4NsjMK1qlpAwaFsG9w0V2tg2gSao=
@@ -342,6 +342,8 @@ github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb
 github.com/filecoin-project/specs-actors/v2 v2.3.5-0.20210114162132-5b58b773f4fb/go.mod h1:LljnY2Mn2homxZsmokJZCpRuhOPxfXhvcek5gWkmqAc=
 github.com/filecoin-project/specs-actors/v3 v3.1.0 h1:s4qiPw8pgypqBGAy853u/zdZJ7K9cTZdM1rTiSonHrg=
 github.com/filecoin-project/specs-actors/v3 v3.1.0/go.mod h1:mpynccOLlIRy0QnR008BwYBwT9fen+sPR13MA1VmMww=
+github.com/filecoin-project/specs-actors/v4 v4.0.0 h1:vMALksY5G3J5rj3q9rbcyB+f4Tk1xrLqSgdB3jOok4s=
+github.com/filecoin-project/specs-actors/v4 v4.0.0/go.mod h1:TkHXf/l7Wyw4ZejyXIPS2rK8bBO0rdwhTZyQQgaglng=
 github.com/filecoin-project/specs-storage v0.1.1-0.20201105051918-5188d9774506 h1:Ur/l2+6qN+lQiqjozWWc5p9UDaAMDZKTlDS98oRnlIw=
 github.com/filecoin-project/specs-storage v0.1.1-0.20201105051918-5188d9774506/go.mod h1:nJRRM7Aa9XVvygr3W9k6xGF46RWzr2zxF/iGoAIfA/g=
 github.com/filecoin-project/test-vectors/schema v0.0.5/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=

--- a/tests/ldevnet.go
+++ b/tests/ldevnet.go
@@ -38,7 +38,7 @@ func LaunchDevnetDocker(t TestingTWithCleanup, numMiners, speed int, ipfsMaddr s
 	}
 
 	repository := "textile/lotus-devnet"
-	tag := "v1.6.0"
+	tag := "v1.8.0"
 	lotusDevnet, err := pool.RunWithOptions(&dockertest.RunOptions{Repository: repository, Tag: tag, Env: envs, Mounts: mounts})
 	require.NoError(t, err)
 	err = lotusDevnet.Expire(180)


### PR DESCRIPTION
Update:
- Lotus client to v1.8.0
- Newly generated docker-image
- Newly generated devnet.