### PR TITLE
Specify which version of Go is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Join us on our [public Slack channel](https://slack.textile.io/) for news, discu
 
 ## Prerequisites
 
-To build from source, you need to have Go 1.14 or newer installed.
+To build from source, you need to have a Go version that is between 1.14.x through 1.17.x. Go 1.18.x and above include a libp2p version that is not currently supported.
 
 ## Design
 


### PR DESCRIPTION
Add a note to the home page about installing Go. Once we have support for newer versions of Go, we will need to modify this again.

Related to https://github.com/textileio/powergate/issues/882 but does not solve it. This only updates the doc.